### PR TITLE
Implement dynamic chat workflow and PDF reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+out
+dist
+.env
+.env.local
+.DS_Store
+coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,97 @@
 # UK-SRD-Compliance
-A tool to help with UK Compliance for ESG Sales
-that (1) educates clients on investment “Preference Pathways”, 
-(2) captures their choices and rationales, (3) validates 
-suitability (ATR/CfL), and (4) generates an e-signable 
-report mapped to the KBS Preference Pathway pack.
+
+This repository now contains a dependency-free Node.js prototype of the SDR Preference
+Pathway chatbot. The goal is to make the workflow runnable on constrained
+machines (e.g. where `npm install` cannot reach the public registry) while still
+respecting the specification’s consent → education → preference capture
+progression. The conversation engine now reacts to user inputs, records answers
+into the canonical JSON structure, and generates a downloadable PDF summary once
+the client approves the draft.
+
+## Running the prototype
+
+1. Ensure Node.js ≥ 18 is available (the environment already provides npm 11.6).
+2. Start the server:
+   ```bash
+   node server/server.js
+   ```
+3. Open <http://localhost:4000> in a browser to interact with the chat surface.
+   - The assistant walks through consent, client profile, informed-choice
+     acknowledgement, preference capture (allocations + SDG / ethical branches),
+     and preview/approval.
+   - After you type “approve”, the page reveals the generated report preview and
+     a PDF download link.
+
+### Quick API smoke test
+
+From a second terminal you can hit the same running server with `curl`:
+
+```bash
+# health check
+curl -s http://localhost:4000/api/health
+
+# start a new in-memory session
+curl -s -X POST http://localhost:4000/api/sessions | jq '.session.id'
+
+# replace SESSION_ID below with the value returned above
+curl -s http://localhost:4000/api/sessions/SESSION_ID/validate | jq '.validation'
+```
+
+`/validate` now accepts either `GET` or `POST`, so the last command works
+verbatim with the ID returned from the session creation response.
+
+No package installation is required – the server uses only built-in Node
+modules and serves a static HTML/JS interface from `public/`.
+
+## Architecture overview
+
+- `server/` contains a lightweight HTTP router, conversation state machine, and
+  validation utilities that mirror the canonical SDR JSON schema.
+- `public/` provides an accessible chat UI that exercises the API. The summary
+  panel shows the evolving session payload and the report section surfaces the
+  rendered preview + PDF download when available.
+
+### API surface
+
+All endpoints live under `/api`:
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/api/health` | Liveness probe |
+| `POST` | `/api/sessions` | Create a session and return the first prompt |
+| `GET` | `/api/sessions/{id}` | Retrieve the latest session snapshot |
+| `POST` | `/api/sessions/{id}/events` | Append chat/audit events and optional data patches |
+| `GET`/`POST` | `/api/sessions/{id}/validate` | Run SDR suitability checks |
+| `GET` | `/api/sessions/{id}/report.pdf` | Download the generated PDF report |
+| `POST` | `/api/reports` | Generate a placeholder DOCX reference (in-memory) |
+| `POST` | `/api/esign/envelopes` | Simulate e-sign envelope creation |
+| `POST` | `/api/esign/webhook` | Accept webhook notifications |
+| `GET` | `/api/adviser/cases` | Adviser overview of active sessions |
+| `GET` | `/api/adviser/cases/{id}` | Detailed case view |
+| `PATCH` | `/api/adviser/cases/{id}` | Update adviser commentary / overrides |
+
+The server keeps everything in-memory so restarting the process clears the data
+(including generated PDFs).
+
+### Validation rules implemented
+
+`server/state/validateSession.js` enforces the key compliance checks from the
+specification:
+
+- Consent acknowledgement is explicit and timestamped.
+- Client profile captures UUID, email, ATR, CfL, and horizon.
+- Pathway allocations sum to 100% with SDG/impact follow-ups when applicable.
+- Ethical screens cannot be left empty when enabled.
+- Bespoke fees require an explanation.
+- Report metadata (version) is set before document generation.
+
+`POST /api/sessions/{id}/validate` returns `{ valid: boolean, issues: string[] }`
+so the UI or adviser console can surface outstanding gaps before drafting the
+report.
+
+## Next steps
+
+- Persist sessions in PostgreSQL or another durable store instead of memory.
+- Replace the placeholder DOCX/ESign handlers with real integrations.
+- Expand the front-end to capture structured questionnaire answers per stage.
+- Add automated unit tests for state transitions and validation edge cases.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "uk-srd-compliance",
+  "private": true,
+  "version": "0.2.0",
+  "type": "module",
+  "scripts": {
+    "start": "node server/server.js"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,135 @@
+const messagesList = document.getElementById("messages");
+const stageLabel = document.getElementById("stage");
+const sessionIdLabel = document.getElementById("session-id");
+const sessionDataBlock = document.getElementById("session-data");
+const composer = document.getElementById("composer");
+const messageInput = document.getElementById("message-input");
+const errorBanner = document.getElementById("error");
+const sendButton = document.getElementById("send-button");
+const reportSection = document.getElementById("report-section");
+const reportPreview = document.getElementById("report-preview");
+const reportDownload = document.getElementById("report-download");
+
+const addMessage = (author, text) => {
+  const item = document.createElement("li");
+  item.dataset.author = author;
+
+  const label = document.createElement("small");
+  label.textContent = author === "client" ? "You" : "Assistant";
+
+  const body = document.createElement("span");
+  body.textContent = text;
+
+  item.appendChild(label);
+  item.appendChild(body);
+  messagesList.appendChild(item);
+  item.scrollIntoView({ behavior: "smooth", block: "end" });
+};
+
+const setStage = (stage) => {
+  stageLabel.textContent = stage ?? "—";
+};
+
+const setSessionId = (sessionId) => {
+  sessionIdLabel.textContent = sessionId ?? "—";
+};
+
+const updateReport = (session) => {
+  const report = session?.data?.report;
+  if (report?.preview) {
+    reportPreview.textContent = report.preview;
+    const downloadUrl = report.doc_url ?? `/api/sessions/${session.id}/report.pdf`;
+    reportDownload.href = downloadUrl;
+    reportSection.hidden = false;
+  } else {
+    reportPreview.textContent = "";
+    reportDownload.removeAttribute("href");
+    reportSection.hidden = true;
+  }
+};
+
+const setSessionData = (session) => {
+  if (!session) return;
+  sessionDataBlock.textContent = JSON.stringify(session.data, null, 2);
+  setStage(session.stage);
+  updateReport(session);
+};
+
+const showError = (message) => {
+  errorBanner.textContent = message;
+  errorBanner.hidden = !message;
+};
+
+const api = async (path, options = {}) => {
+  const response = await fetch(`/api${path}`, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+    ...options,
+    body: options.body ? JSON.stringify(options.body) : undefined
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const error = payload.error || response.statusText || "Request failed";
+    throw new Error(error);
+  }
+
+  return response.json();
+};
+
+let currentSessionId = null;
+
+const bootstrap = async () => {
+  try {
+    const data = await api("/sessions", { method: "POST" });
+    currentSessionId = data.session.id;
+    setSessionId(currentSessionId);
+    setSessionData(data.session);
+    data.messages.forEach((message) => addMessage("assistant", message));
+  } catch (error) {
+    showError(error.message);
+    sendButton.disabled = true;
+  }
+};
+
+composer.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  showError("");
+
+  if (!currentSessionId) {
+    showError("Session not ready yet. Please refresh the page.");
+    return;
+  }
+
+  const text = messageInput.value.trim();
+  if (!text) {
+    return;
+  }
+
+  addMessage("client", text);
+  messageInput.value = "";
+  messageInput.focus();
+  sendButton.disabled = true;
+
+  try {
+    const eventResponse = await api(`/sessions/${currentSessionId}/events`, {
+      method: "POST",
+      body: {
+        author: "client",
+        type: "message",
+        content: { text }
+      }
+    });
+
+    setSessionData(eventResponse.session);
+    (eventResponse.messages ?? []).forEach((message) =>
+      addMessage("assistant", message)
+    );
+  } catch (error) {
+    showError(error.message);
+  } finally {
+    sendButton.disabled = false;
+  }
+});
+
+bootstrap();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SDR Preference Pathway Assistant</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <h1>SDR Preference Pathway Assistant</h1>
+        <p>
+          This prototype demonstrates the consent → education → preference capture
+          journey described in the SDR specification. All data is stored in memory
+          for the current server session only.
+        </p>
+      </header>
+
+      <section class="status" aria-live="polite">
+        <div>
+          <h2>Current stage</h2>
+          <p id="stage">Loading…</p>
+        </div>
+        <div>
+          <h2>Session ID</h2>
+          <p id="session-id">—</p>
+        </div>
+      </section>
+
+      <section class="chat" aria-label="Chat transcript">
+        <ul id="messages" class="chat__messages"></ul>
+        <form id="composer" class="composer" autocomplete="off">
+          <label class="composer__label" for="message-input">
+            Respond to continue the onboarding conversation
+          </label>
+          <textarea
+            id="message-input"
+            name="message"
+            required
+            placeholder="Type your response"
+            rows="3"
+          ></textarea>
+          <button type="submit" id="send-button">Send</button>
+          <p id="error" role="alert" class="composer__error" hidden></p>
+        </form>
+      </section>
+
+      <section class="summary" aria-live="polite">
+        <h2>Captured data (draft)</h2>
+        <pre id="session-data">{}</pre>
+      </section>
+
+      <section class="report" id="report-section" hidden aria-live="polite">
+        <h2>Report preview</h2>
+        <p>
+          The assistant generates a summary report once you approve the draft.
+          Review the on-screen copy and download the PDF for your records.
+        </p>
+        <pre id="report-preview"></pre>
+        <a id="report-download" href="#" download="preference-pathway.pdf">
+          Download PDF report
+        </a>
+      </section>
+    </main>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,229 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  line-height: 1.5;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: auto auto 1fr;
+  gap: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.app__header {
+  grid-column: 1 / -1;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.5);
+}
+
+.app__header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+}
+
+.status {
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  padding: 1.25rem;
+}
+
+.status h2 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #38bdf8;
+}
+
+.status p {
+  margin: 0.25rem 0 0;
+  font-weight: 600;
+}
+
+.chat {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chat__messages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 55vh;
+  overflow-y: auto;
+}
+
+.chat__messages li {
+  display: grid;
+  gap: 0.25rem;
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+}
+
+.chat__messages li[data-author="client"] {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.5);
+}
+
+.chat__messages small {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: #38bdf8;
+}
+
+.chat__messages span {
+  font-size: 1rem;
+}
+
+.composer {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.composer__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.composer textarea {
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: inherit;
+  padding: 0.75rem;
+  resize: vertical;
+  font: inherit;
+}
+
+.composer textarea:focus {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
+.composer button {
+  justify-self: end;
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+  color: #0f172a;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.composer button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.composer button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(14, 165, 233, 0.4);
+}
+
+.composer__error {
+  margin: 0;
+  color: #f87171;
+  font-weight: 600;
+}
+
+.summary {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  overflow: auto;
+}
+
+.summary pre {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  max-height: 50vh;
+  overflow: auto;
+  font-size: 0.85rem;
+}
+
+.report {
+  grid-column: 1 / -1;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.report pre {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.report a {
+  justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(56, 189, 248, 0.2);
+  border: 1px solid rgba(56, 189, 248, 0.5);
+  border-radius: 999px;
+  padding: 0.65rem 1.25rem;
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.report a:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(56, 189, 248, 0.35);
+}
+
+@media (max-width: 900px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .status {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/server/httpUtils.js
+++ b/server/httpUtils.js
@@ -1,0 +1,69 @@
+import { extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFile } from "node:fs/promises";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const publicDir = join(__dirname, "../public");
+
+const mimeTypes = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8"
+};
+
+export const sendJSON = (res, status, payload) => {
+  const body = JSON.stringify(payload, null, 2);
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Methods": "GET,POST,PATCH,OPTIONS"
+  });
+  res.end(body);
+};
+
+export const sendText = (res, status, text, contentType = "text/plain; charset=utf-8") => {
+  res.writeHead(status, {
+    "Content-Type": contentType,
+    "Access-Control-Allow-Origin": "*"
+  });
+  res.end(text);
+};
+
+export const sendNoContent = (res) => {
+  res.writeHead(204, {
+    "Access-Control-Allow-Origin": "*"
+  });
+  res.end();
+};
+
+export const sendOptions = (res) => {
+  res.writeHead(204, {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Methods": "GET,POST,PATCH,OPTIONS"
+  });
+  res.end();
+};
+
+export const serveStaticFile = async (res, pathname) => {
+  const filePath = pathname === "/"
+    ? join(publicDir, "index.html")
+    : join(publicDir, pathname.replace(/^\//, ""));
+
+  try {
+    const extension = extname(filePath) || ".html";
+    const contentType = mimeTypes[extension] ?? "text/plain; charset=utf-8";
+    const file = await readFile(filePath);
+    res.writeHead(200, {
+      "Content-Type": contentType
+    });
+    res.end(file);
+  } catch (error) {
+    if (pathname !== "/" && !extname(pathname)) {
+      return serveStaticFile(res, "/");
+    }
+    sendText(res, 404, "Not found");
+  }
+};

--- a/server/report/reportGenerator.js
+++ b/server/report/reportGenerator.js
@@ -1,0 +1,129 @@
+const escapePdfText = (text) =>
+  text
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)")
+    .replace(/\r?\n/g, "\\n");
+
+const buildPdfBuffer = (lines) => {
+  const contentLines = [
+    "BT",
+    "/F1 12 Tf",
+    "14 TL",
+    "72 750 Td"
+  ];
+
+  lines.forEach((line, index) => {
+    if (index > 0) {
+      contentLines.push("T*");
+    }
+    contentLines.push(`(${escapePdfText(line)}) Tj`);
+  });
+
+  contentLines.push("ET");
+
+  const contentStream = contentLines.join("\n");
+  const contentLength = Buffer.byteLength(contentStream, "utf8");
+
+  const objects = [];
+  const addObject = (body) => {
+    objects.push(body);
+    return objects.length;
+  };
+
+  addObject("<< /Type /Catalog /Pages 2 0 R >>");
+  addObject("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+  addObject(
+    "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /MediaBox [0 0 612 792] /Contents 5 0 R >>"
+  );
+  addObject("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+  addObject(`<< /Length ${contentLength} >>\nstream\n${contentStream}\nendstream`);
+
+  const xref = [0];
+  let body = "%PDF-1.4\n";
+
+  objects.forEach((object, index) => {
+    const position = Buffer.byteLength(body, "utf8");
+    xref.push(position);
+    body += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+
+  const xrefStart = Buffer.byteLength(body, "utf8");
+  body += "xref\n";
+  body += `0 ${objects.length + 1}\n`;
+  body += "0000000000 65535 f \n";
+
+  for (let i = 1; i < xref.length; i += 1) {
+    body += `${String(xref[i]).padStart(10, "0")} 00000 n \n`;
+  }
+
+  body += "trailer\n";
+  body += `<< /Size ${objects.length + 1} /Root 1 0 R >>\n`;
+  body += "startxref\n";
+  body += `${xrefStart}\n`;
+  body += "%%EOF";
+
+  return Buffer.from(body, "utf8");
+};
+
+const buildPreview = (session) => {
+  const previewLines = [];
+  const client = session.data.client ?? {};
+  const preferences = session.data.preferences ?? {};
+
+  previewLines.push(`Client: ${client.name ?? "Unknown"}`);
+  previewLines.push(
+    `ATR: ${client.risk?.atr ?? "—"} | CfL: ${client.risk?.cfl ?? "—"} | Horizon: ${client.risk?.horizon_years ?? "—"} years`
+  );
+  previewLines.push("");
+  previewLines.push("Acknowledged informed choice: " +
+    (session.data.acknowledgements?.read_informed_choice ? "Yes" : "No"));
+  previewLines.push("");
+  previewLines.push("Pathway allocations:");
+
+  (preferences.pathways ?? []).forEach((pathway) => {
+    const details = [];
+    if (pathway.themes?.length) {
+      details.push(`Themes: ${pathway.themes.join(", ")}`);
+    }
+    if (pathway.impact_goals?.length) {
+      details.push(`Impact goals: ${pathway.impact_goals.join(", ")}`);
+    }
+    previewLines.push(
+      `- ${pathway.name} — ${pathway.allocation_pct}%${
+        details.length ? ` (${details.join("; ")})` : ""
+      }`
+    );
+  });
+
+  if (preferences.ethical?.enabled) {
+    previewLines.push(
+      `Ethical screens: ${preferences.ethical.exclusions.join(", ") || "None specified"}`
+    );
+  }
+
+  previewLines.push(
+    `Stewardship discretion: ${preferences.stewardship?.discretion ?? "fund_manager"}`
+  );
+  previewLines.push("");
+  previewLines.push(
+    `Products: ${(session.data.products ?? [])
+      .map((item) => item.wrapper)
+      .join(", ") || "Not specified"}`
+  );
+  previewLines.push("");
+  previewLines.push("Adviser notes:");
+  previewLines.push(session.data.adviser_notes || "To be confirmed");
+
+  return previewLines.join("\n");
+};
+
+export const generateReportArtifacts = (session) => {
+  const preview = buildPreview(session);
+  const pdfBuffer = buildPdfBuffer(preview.split("\n"));
+
+  return {
+    preview,
+    pdfBuffer
+  };
+};

--- a/server/report/reportStore.js
+++ b/server/report/reportStore.js
@@ -1,0 +1,7 @@
+const reports = new Map();
+
+export const storeReportArtifacts = (sessionId, buffer) => {
+  reports.set(sessionId, buffer);
+};
+
+export const getReportArtifact = (sessionId) => reports.get(sessionId) ?? null;

--- a/server/router.js
+++ b/server/router.js
@@ -1,0 +1,360 @@
+import { randomUUID } from "node:crypto";
+import { URL } from "node:url";
+import {
+  createSession,
+  getSession,
+  listSessions,
+  saveSession,
+  appendEvent,
+  applyDataPatch,
+  toPublicSession
+} from "./state/sessionStore.js";
+import { validateSessionData } from "./state/validateSession.js";
+import {
+  EVENT_AUTHORS,
+  EVENT_TYPES,
+  STAGE_PROMPTS
+} from "./state/constants.js";
+import {
+  sendJSON,
+  sendText,
+  sendOptions,
+  serveStaticFile
+} from "./httpUtils.js";
+import { handleEvent } from "./state/conversationEngine.js";
+import { getReportArtifact } from "./report/reportStore.js";
+
+const API_PREFIX = "/api";
+
+const readBody = async (req) => {
+  if (req.method === "GET" || req.method === "HEAD") {
+    return {};
+  }
+
+  let raw = "";
+  for await (const chunk of req) {
+    raw += chunk;
+    if (raw.length > 1_000_000) {
+      throw new Error("Request body too large");
+    }
+  }
+
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    const err = new Error("Invalid JSON body");
+    err.status = 400;
+    throw err;
+  }
+};
+
+const ensureSession = (res, id) => {
+  const session = getSession(id);
+  if (!session) {
+    sendJSON(res, 404, { error: "Session not found" });
+    return null;
+  }
+  return session;
+};
+
+const handleCreateSession = (req, res) => {
+  const session = createSession({ ip: req.socket.remoteAddress });
+  sendJSON(res, 201, {
+    session: toPublicSession(session),
+    messages: [STAGE_PROMPTS[session.stage]]
+  });
+};
+
+const handleGetSession = (res, id) => {
+  const session = ensureSession(res, id);
+  if (!session) return;
+  sendJSON(res, 200, {
+    session: toPublicSession(session),
+    messages: [STAGE_PROMPTS[session.stage]]
+  });
+};
+
+const handleAppendEvent = async (req, res, id) => {
+  const session = ensureSession(res, id);
+  if (!session) return;
+
+  const body = await readBody(req);
+  const { author, type, content = {}, stageData } = body;
+
+  if (!EVENT_AUTHORS.includes(author)) {
+    sendJSON(res, 400, { error: "Invalid event author" });
+    return;
+  }
+
+  if (!EVENT_TYPES.includes(type)) {
+    sendJSON(res, 400, { error: "Invalid event type" });
+    return;
+  }
+
+  if (typeof content !== "object") {
+    sendJSON(res, 400, { error: "Event content must be an object" });
+    return;
+  }
+
+  if (stageData && typeof stageData !== "object") {
+    sendJSON(res, 400, { error: "stageData must be an object when provided" });
+    return;
+  }
+
+  const event = {
+    id: randomUUID(),
+    sessionId: session.id,
+    author,
+    type,
+    content,
+    createdAt: new Date().toISOString()
+  };
+
+  appendEvent(session, event);
+  if (stageData) {
+    applyDataPatch(session, stageData);
+  }
+
+  const result = handleEvent(session, event);
+  saveSession(session);
+
+  sendJSON(res, 201, {
+    event,
+    session: toPublicSession(session),
+    messages: result.messages
+  });
+};
+
+const handleValidate = (res, id) => {
+  const session = ensureSession(res, id);
+  if (!session) return;
+  const validation = validateSessionData(session);
+  sendJSON(res, 200, {
+    session: toPublicSession(session),
+    validation
+  });
+};
+
+const handleReportGeneration = async (req, res) => {
+  const body = await readBody(req);
+  const sessionId = body.session_id;
+  const session = ensureSession(res, sessionId);
+  if (!session) return;
+
+  const validation = validateSessionData(session);
+  if (!validation.valid) {
+    sendJSON(res, 422, {
+      error: "Session is not ready for report generation",
+      issues: validation.issues
+    });
+    return;
+  }
+
+  session.data.report.doc_url = `memory://reports/${session.id}.docx`;
+  session.data.report.status = "draft";
+  saveSession(session);
+
+  sendJSON(res, 201, {
+    report: session.data.report,
+    session: toPublicSession(session)
+  });
+};
+
+const handleCreateEnvelope = async (req, res) => {
+  const body = await readBody(req);
+  const sessionId = body.session_id;
+  const session = ensureSession(res, sessionId);
+  if (!session) return;
+
+  const signUrl = `https://example.com/sign/${session.id}`;
+  session.data.report.status = "awaiting_signature";
+  session.data.report.signed_url = null;
+  saveSession(session);
+
+  sendJSON(res, 201, {
+    envelope: {
+      id: `env_${session.id}`,
+      sign_url: signUrl
+    },
+    session: toPublicSession(session)
+  });
+};
+
+const handleEnvelopeWebhook = async (req, res) => {
+  const body = await readBody(req);
+  const sessionId = body.session_id;
+  const session = ensureSession(res, sessionId);
+  if (!session) return;
+
+  if (body.status === "completed" && body.signed_url) {
+    session.data.report.status = "completed";
+    session.data.report.signed_url = body.signed_url;
+  }
+
+  saveSession(session);
+  sendText(res, 202, "Webhook received");
+};
+
+const handleListCases = (res) => {
+  const cases = listSessions().map((session) => ({
+    id: session.id,
+    stage: session.stage,
+    updatedAt: session.updatedAt,
+    clientName: session.data.client?.name ?? null,
+    pathwayCount: session.data.preferences?.pathways?.length ?? 0
+  }));
+
+  sendJSON(res, 200, { cases });
+};
+
+const handleGetCase = (res, id) => {
+  const session = ensureSession(res, id);
+  if (!session) return;
+  sendJSON(res, 200, { case: toPublicSession(session) });
+};
+
+const handlePatchCase = async (req, res, id) => {
+  const session = ensureSession(res, id);
+  if (!session) return;
+
+  const body = await readBody(req);
+  const { adviser_notes, fees, overrides } = body;
+
+  const patch = {};
+  if (typeof adviser_notes === "string") {
+    patch.adviser_notes = adviser_notes;
+  }
+  if (fees && typeof fees === "object") {
+    patch.fees = fees;
+  }
+  if (overrides && typeof overrides === "object") {
+    Object.assign(patch, overrides);
+  }
+
+  applyDataPatch(session, patch);
+
+  appendEvent(session, {
+    id: randomUUID(),
+    sessionId: session.id,
+    author: "adviser",
+    type: "note",
+    content: {
+      adviser_notes: adviser_notes ?? null
+    },
+    createdAt: new Date().toISOString()
+  });
+
+  saveSession(session);
+  sendJSON(res, 200, { case: toPublicSession(session) });
+};
+
+export const handleRequest = async (req, res) => {
+  if (req.method === "OPTIONS") {
+    sendOptions(res);
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const pathname = url.pathname;
+
+  if (!pathname.startsWith(API_PREFIX)) {
+    await serveStaticFile(res, pathname);
+    return;
+  }
+
+  const apiPath = pathname.slice(API_PREFIX.length) || "/";
+  const segments = apiPath.split("/").filter(Boolean);
+
+  try {
+    if (req.method === "GET" && apiPath === "/health") {
+      sendJSON(res, 200, { status: "ok" });
+      return;
+    }
+
+    if (req.method === "POST" && apiPath === "/sessions") {
+      handleCreateSession(req, res);
+      return;
+    }
+
+    if (segments[0] === "sessions" && segments.length >= 2) {
+      const sessionId = segments[1];
+      const tail = segments.slice(2).join("/");
+
+      if (req.method === "GET" && segments.length === 2) {
+        handleGetSession(res, sessionId);
+        return;
+      }
+
+      if (req.method === "POST" && tail === "events") {
+        await handleAppendEvent(req, res, sessionId);
+        return;
+      }
+
+      if ((req.method === "POST" || req.method === "GET") && tail === "validate") {
+        handleValidate(res, sessionId);
+        return;
+      }
+
+      if (req.method === "GET" && tail === "report.pdf") {
+        const pdf = getReportArtifact(sessionId);
+        if (!pdf) {
+          sendJSON(res, 404, { error: "Report not generated yet" });
+          return;
+        }
+
+        res.writeHead(200, {
+          "Content-Type": "application/pdf",
+          "Content-Disposition": `attachment; filename="preference-pathway-${sessionId}.pdf"`,
+          "Content-Length": pdf.length
+        });
+        res.end(pdf);
+        return;
+      }
+    }
+
+    if (req.method === "POST" && apiPath === "/reports") {
+      await handleReportGeneration(req, res);
+      return;
+    }
+
+    if (req.method === "POST" && apiPath === "/esign/envelopes") {
+      await handleCreateEnvelope(req, res);
+      return;
+    }
+
+    if (req.method === "POST" && apiPath === "/esign/webhook") {
+      await handleEnvelopeWebhook(req, res);
+      return;
+    }
+
+    if (segments[0] === "adviser" && segments[1] === "cases") {
+      if (req.method === "GET" && segments.length === 2) {
+        handleListCases(res);
+        return;
+      }
+
+      if (segments.length === 3) {
+        const caseId = segments[2];
+        if (req.method === "GET") {
+          handleGetCase(res, caseId);
+          return;
+        }
+        if (req.method === "PATCH") {
+          await handlePatchCase(req, res, caseId);
+          return;
+        }
+      }
+    }
+
+    sendJSON(res, 404, { error: "Route not found" });
+  } catch (error) {
+    const status = error.status ?? 500;
+    sendJSON(res, status, {
+      error: error.message ?? "Unexpected error"
+    });
+  }
+};

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,28 @@
+import http from "node:http";
+import { handleRequest } from "./router.js";
+
+const port = Number(process.env.PORT ?? 4000);
+
+const server = http.createServer(async (req, res) => {
+  try {
+    await handleRequest(req, res);
+  } catch (error) {
+    console.error("Unexpected server error", error);
+    res.writeHead(500, {
+      "Content-Type": "application/json; charset=utf-8",
+      "Access-Control-Allow-Origin": "*"
+    });
+    res.end(JSON.stringify({ error: "Internal server error" }));
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Server ready on http://localhost:${port}`);
+});
+
+process.on("SIGINT", () => {
+  server.close(() => {
+    console.log("Server stopped");
+    process.exit(0);
+  });
+});

--- a/server/state/constants.js
+++ b/server/state/constants.js
@@ -1,0 +1,53 @@
+export const CONVERSATION_STAGES = [
+  "S0_CONSENT",
+  "S1_IDENTITY_PROFILE",
+  "S2_EDUCATION",
+  "S3_PREFERENCE_CAPTURE",
+  "S4_ADVISER_VALIDATION",
+  "S5_PREVIEW_APPROVAL",
+  "S6_E_SIGNATURE",
+  "S7_ARCHIVE"
+];
+
+export const STAGE_PROMPTS = {
+  S0_CONSENT:
+    "Before we begin, please review our privacy disclosure and confirm that we may process your information.",
+  S1_IDENTITY_PROFILE:
+    "Let's capture your contact details, investment horizon, attitude to risk (ATR), and capacity for loss (CfL).",
+  S2_EDUCATION:
+    "Here is an overview of each Preference Pathway. Remember that there is no hierarchy between the strategies.",
+  S3_PREFERENCE_CAPTURE:
+    "Tell me which pathways you would like to pursue and how you would allocate percentages between them.",
+  S4_ADVISER_VALIDATION:
+    "An adviser will confirm that your selections align with your ATR, CfL, and product wrappers.",
+  S5_PREVIEW_APPROVAL:
+    "Please review the draft report before we request your signature.",
+  S6_E_SIGNATURE:
+    "We are preparing the documentation for e-signature.",
+  S7_ARCHIVE:
+    "All signed documents and transcripts are archived in line with our compliance policy."
+};
+
+export const PATHWAY_NAMES = [
+  "Conventional",
+  "Conventional incl. ESG",
+  "Sustainability: Improvers",
+  "Sustainability: Focus",
+  "Sustainability: Impact",
+  "Sustainability: Mixed Goals",
+  "Ethical",
+  "Philanthropy"
+];
+
+export const ATR_VALUES = ["Cautious", "Balanced", "Adventurous"];
+export const CFL_VALUES = ["Low", "Medium", "High"];
+export const STEWARDSHIP_OPTIONS = ["fund_manager", "client_questionnaire"];
+
+export const EVENT_AUTHORS = [
+  "client",
+  "assistant",
+  "adviser",
+  "system"
+];
+
+export const EVENT_TYPES = ["message", "note", "data_update"];

--- a/server/state/conversationEngine.js
+++ b/server/state/conversationEngine.js
@@ -1,0 +1,572 @@
+import {
+  ATR_VALUES,
+  CFL_VALUES,
+  PATHWAY_NAMES,
+  STEWARDSHIP_OPTIONS,
+  STAGE_PROMPTS
+} from "./constants.js";
+import {
+  applyDataPatch,
+  saveSession,
+  setStage
+} from "./sessionStore.js";
+import { validateSessionData } from "./validateSession.js";
+import { generateReportArtifacts } from "../report/reportGenerator.js";
+import { storeReportArtifacts } from "../report/reportStore.js";
+
+const yesPatterns = /\b(yes|yep|i (consent|agree|understand)|sure|ok(ay)?)\b/i;
+
+const normalise = (value) => value.trim().toLowerCase();
+
+const PATHWAY_MATCH_ORDER = [...PATHWAY_NAMES].sort(
+  (a, b) => b.length - a.length
+);
+
+const findPathwayByAlias = (fragment) => {
+  const normalised = normalise(fragment);
+  return (
+    PATHWAY_MATCH_ORDER.find((name) =>
+      normalised.includes(normalise(name))
+    ) ?? null
+  );
+};
+
+const splitList = (text) =>
+  text
+    .split(/[,\n]|\band\b/gi)
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const parseAllocations = (input) => {
+  const chunks = splitList(input.replace(/percent|%/gi, "%"));
+  const allocations = [];
+
+  for (const chunk of chunks) {
+    const percentMatch = chunk.match(/(-?\d{1,3})/);
+    if (!percentMatch) {
+      continue;
+    }
+
+    const percent = Number.parseInt(percentMatch[1], 10);
+    if (Number.isNaN(percent)) {
+      continue;
+    }
+
+    let pathway = findPathwayByAlias(chunk);
+    if (!pathway) {
+      for (const name of PATHWAY_NAMES) {
+        const pattern = new RegExp(escapeRegex(name), "i");
+        if (pattern.test(chunk)) {
+          pathway = name;
+          break;
+        }
+      }
+    }
+
+    if (!pathway) {
+      continue;
+    }
+
+    allocations.push({ name: pathway, allocation_pct: percent });
+  }
+
+  return allocations;
+};
+
+const ensureClientShape = (session) => {
+  if (!session.data.client) {
+    session.data.client = {
+      id: session.data.client?.id ?? session.id,
+      name: "",
+      contact: { email: "", phone: "" },
+      risk: { atr: "", cfl: "", horizon_years: 0 }
+    };
+  }
+};
+
+const ensurePreferenceDefaults = (session) => {
+  if (!session.data.preferences) {
+    session.data.preferences = {
+      pathways: [],
+      ethical: { enabled: false, exclusions: [] },
+      stewardship: { discretion: "fund_manager" }
+    };
+  }
+};
+
+const stageResponse = (session, stage, additionalMessages = []) => {
+  if (session.stage !== stage) {
+    setStage(session, stage);
+  }
+
+  const prompt = STAGE_PROMPTS[stage];
+  return prompt ? [prompt, ...additionalMessages] : additionalMessages;
+};
+
+const moveToStage = (session, stage, extraMessages = []) => {
+  const messages = stageResponse(session, stage, extraMessages);
+  saveSession(session);
+  return { messages };
+};
+
+const handleConsent = (session, text) => {
+  if (!yesPatterns.test(text)) {
+    return {
+      messages: [
+        "I need your explicit consent to continue. Please reply with 'Yes' if you agree to proceed." 
+      ]
+    };
+  }
+
+  applyDataPatch(session, {
+    acknowledgements: {
+      read_informed_choice: false,
+      timestamp: new Date().toISOString()
+    },
+    audit: {
+      events: session.data.audit.events,
+      ip: session.data.audit.ip
+    }
+  });
+
+  session.context.profileStep = 0;
+
+  return moveToStage(session, "S1_IDENTITY_PROFILE", [
+    "Thank you. Let's begin with a few details about you.",
+    "What is your full name?"
+  ]);
+};
+
+const handleProfile = (session, text) => {
+  ensureClientShape(session);
+  const client = session.data.client;
+  const step = session.context.profileStep ?? 0;
+
+  if (step === 0) {
+    client.name = text.trim();
+    session.context.profileStep = 1;
+    saveSession(session);
+    return { messages: ["Thanks, " + client.name + ". What is your email address?"] };
+  }
+
+  if (step === 1) {
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailPattern.test(text.trim())) {
+      return { messages: ["That email doesn't look valid. Could you double-check and resend it?"] };
+    }
+    client.contact.email = text.trim();
+    session.context.profileStep = 2;
+    saveSession(session);
+    return {
+      messages: [
+        "Got it. Which attitude to risk (ATR) best describes you? Choose from: " +
+          ATR_VALUES.join(", ") + "."
+      ]
+    };
+  }
+
+  if (step === 2) {
+    const choice = ATR_VALUES.find(
+      (value) => normalise(value) === normalise(text)
+    );
+    if (!choice) {
+      return {
+        messages: [
+          "Please choose one of the ATR options: " + ATR_VALUES.join(", ") + "."
+        ]
+      };
+    }
+    client.risk.atr = choice;
+    session.context.profileStep = 3;
+    saveSession(session);
+    return {
+      messages: [
+        "Thank you. What is your capacity for loss (CfL)? Options: " +
+          CFL_VALUES.join(", ") + "."
+      ]
+    };
+  }
+
+  if (step === 3) {
+    const choice = CFL_VALUES.find(
+      (value) => normalise(value) === normalise(text)
+    );
+    if (!choice) {
+      return {
+        messages: [
+          "Please choose one of the CfL options: " + CFL_VALUES.join(", ") + "."
+        ]
+      };
+    }
+    client.risk.cfl = choice;
+    session.context.profileStep = 4;
+    saveSession(session);
+    return {
+      messages: [
+        "Understood. What is your investment horizon in years? (Please enter a number.)"
+      ]
+    };
+  }
+
+  if (step === 4) {
+    const years = Number.parseInt(text.trim(), 10);
+    if (!Number.isFinite(years) || years <= 0) {
+      return {
+        messages: ["Please provide the number of years as a positive whole number."]
+      };
+    }
+    client.risk.horizon_years = years;
+    session.context.profileStep = 5;
+    saveSession(session);
+    return {
+      messages: [
+        "Thanks. Which product wrappers are you considering? (For example: ISA, Pension)."
+      ]
+    };
+  }
+
+  if (step === 5) {
+    const wrappers = splitList(text);
+    applyDataPatch(session, {
+      products: wrappers.map((wrapper) => ({ wrapper }))
+    });
+    session.context.profileStep = 6;
+    session.context.educationAcknowledged = false;
+
+    return moveToStage(session, "S2_EDUCATION", [
+      "Great. Here's a quick overview of each pathway: Conventional, Conventional incl. ESG, Improvers, Focus, Impact, Mixed Goals, Ethical, and Philanthropy. None is ranked above the others—they simply suit different objectives.",
+      "Please confirm once you've read this summary so we can record your informed choice acknowledgment."
+    ]);
+  }
+
+  return { messages: ["Let me summarise before we continue."] };
+};
+
+const handleEducation = (session, text) => {
+  if (!yesPatterns.test(text)) {
+    return {
+      messages: [
+        "Take your time. When you're ready, reply with 'I understand' so I can log your acknowledgment."
+      ]
+    };
+  }
+
+  applyDataPatch(session, {
+    acknowledgements: {
+      read_informed_choice: true,
+      timestamp: new Date().toISOString()
+    }
+  });
+
+  session.context.preference = {
+    allocationsCaptured: false,
+    needImpactThemes: false,
+    needEthicalDetail: false,
+    stewardshipAnswered: false
+  };
+
+  return moveToStage(session, "S3_PREFERENCE_CAPTURE", [
+    "Which pathways would you like to select and how would you allocate percentages between them? You can reply for example: 'Focus 50%, Impact 30%, Conventional incl. ESG 20%'."
+  ]);
+};
+
+const applyPreferenceAllocations = (session, allocations) => {
+  ensurePreferenceDefaults(session);
+  const unique = new Map();
+  for (const allocation of allocations) {
+    unique.set(allocation.name, allocation);
+  }
+  session.data.preferences.pathways = Array.from(unique.values());
+};
+
+const handlePreferenceCapture = (session, text) => {
+  ensurePreferenceDefaults(session);
+  const prefContext = session.context.preference ?? {
+    allocationsCaptured: false,
+    needImpactThemes: false,
+    needEthicalDetail: false,
+    stewardshipAnswered: false
+  };
+
+  if (!prefContext.allocationsCaptured) {
+    const allocations = parseAllocations(text);
+    const total = allocations.reduce((sum, item) => sum + item.allocation_pct, 0);
+
+    if (allocations.length === 0 || total !== 100) {
+      return {
+        messages: [
+          "I couldn't record that. Please list each pathway with its percentage so the total equals 100."
+        ]
+      };
+    }
+
+    applyPreferenceAllocations(session, allocations);
+
+    prefContext.allocationsCaptured = true;
+    prefContext.needImpactThemes = session.data.preferences.pathways.some((pathway) =>
+      [
+        "Sustainability: Focus",
+        "Sustainability: Impact",
+        "Sustainability: Mixed Goals"
+      ].includes(pathway.name)
+    );
+    prefContext.needEthicalDetail = session.data.preferences.pathways.some(
+      (pathway) => pathway.name === "Ethical"
+    );
+
+    session.context.preference = prefContext;
+    saveSession(session);
+
+    if (prefContext.needImpactThemes) {
+      return {
+        messages: [
+          "Thanks. Which SDG themes or impact goals should we highlight for your Focus/Impact/Mixed Goals pathways?"
+        ]
+      };
+    }
+
+    if (prefContext.needEthicalDetail) {
+      return {
+        messages: [
+          "Please list any ethical screens, inclusions, or exclusions you'd like noted."
+        ]
+      };
+    }
+
+    return {
+      messages: [
+        "Would you like to leave stewardship discretion with the fund manager or complete a questionnaire yourself?"
+      ]
+    };
+  }
+
+  if (prefContext.needImpactThemes) {
+    const items = splitList(text);
+    for (const pathway of session.data.preferences.pathways) {
+      if (pathway.name === "Sustainability: Focus") {
+        pathway.themes = items;
+        pathway.uses_sdgs = true;
+      }
+      if (pathway.name === "Sustainability: Impact") {
+        pathway.impact_goals = items;
+        pathway.uses_sdgs = true;
+      }
+      if (pathway.name === "Sustainability: Mixed Goals") {
+        pathway.themes = items;
+        pathway.impact_goals = items;
+        pathway.uses_sdgs = true;
+      }
+    }
+    prefContext.needImpactThemes = false;
+    session.context.preference = prefContext;
+    saveSession(session);
+
+    if (prefContext.needEthicalDetail) {
+      return {
+        messages: [
+          "Noted. Please list any ethical screens, inclusions, or exclusions you'd like documented."
+        ]
+      };
+    }
+
+    return {
+      messages: [
+        "Would you like to leave stewardship discretion with the fund manager or complete a questionnaire yourself?"
+      ]
+    };
+  }
+
+  if (prefContext.needEthicalDetail) {
+    const noPreference = /\b(no|none|not at this time)\b/i;
+    if (noPreference.test(text)) {
+      session.data.preferences.ethical = {
+        enabled: false,
+        exclusions: []
+      };
+    } else {
+      session.data.preferences.ethical = {
+        enabled: true,
+        exclusions: splitList(text)
+      };
+    }
+    prefContext.needEthicalDetail = false;
+    session.context.preference = prefContext;
+    saveSession(session);
+
+    return {
+      messages: [
+        "Would you like to leave stewardship discretion with the fund manager or complete a questionnaire yourself?"
+      ]
+    };
+  }
+
+  if (!prefContext.stewardshipAnswered) {
+    const answer = normalise(text);
+    const option = STEWARDSHIP_OPTIONS.find((item) => answer.includes(item.replace("_", " ")));
+
+    if (!option) {
+      return {
+        messages: [
+          "Please let me know if the discretion should stay with the fund manager or if you'd prefer to complete a questionnaire."
+        ]
+      };
+    }
+
+    session.data.preferences.stewardship = { discretion: option };
+    session.context.preference.stewardshipAnswered = true;
+    session.context.preference.allocationsCaptured = true;
+    session.context.preference.needEthicalDetail = false;
+    session.context.preference.needImpactThemes = false;
+
+    return moveToStage(session, "S4_ADVISER_VALIDATION", [
+      "Perfect. I'll package this for your adviser to review the suitability narrative.",
+      "When you're ready, type 'preview' and I'll build a draft report for you to check before signature."
+    ]);
+  }
+
+  return { messages: ["Let me know when you'd like the preview."] };
+};
+
+const summarisePreferences = (session) => {
+  const lines = [];
+  const clientName = session.data.client?.name ?? "Client";
+  lines.push(`Preference Pathway Summary for ${clientName}`);
+  lines.push("Allocations:");
+  for (const pathway of session.data.preferences.pathways) {
+    const details = [];
+    if (pathway.themes?.length) {
+      details.push(`Themes: ${pathway.themes.join(", ")}`);
+    }
+    if (pathway.impact_goals?.length) {
+      details.push(`Impact goals: ${pathway.impact_goals.join(", ")}`);
+    }
+    lines.push(`- ${pathway.name}: ${pathway.allocation_pct}%${
+      details.length ? ` (${details.join("; ")})` : ""
+    }`);
+  }
+  if (session.data.preferences.ethical?.enabled) {
+    lines.push(
+      `Ethical exclusions: ${session.data.preferences.ethical.exclusions.join(", ")}`
+    );
+  }
+  lines.push(
+    `Stewardship discretion: ${session.data.preferences.stewardship?.discretion}`
+  );
+  return lines.join("\n");
+};
+
+const handleAdviserValidation = (session, text) => {
+  if (!/preview|ready|build/i.test(text)) {
+    return {
+      messages: [
+        "Once you're ready for the preview, reply with 'Preview' or 'Ready'."
+      ]
+    };
+  }
+
+  const validation = validateSessionData(session);
+  if (!validation.valid) {
+    return {
+      messages: [
+        "We're missing a few details before I can produce the report:",
+        ...validation.issues
+      ]
+    };
+  }
+
+  session.data.adviser_notes =
+    session.data.adviser_notes ||
+    `Session ${session.id} auto-generated narrative. ATR ${session.data.client?.risk?.atr}, CfL ${session.data.client?.risk?.cfl}.`;
+
+  return moveToStage(session, "S5_PREVIEW_APPROVAL", [
+    "Here's a summary of what we've captured:",
+    summarisePreferences(session),
+    "Reply with 'Approve' when this looks right and I'll generate the PDF report."
+  ]);
+};
+
+const handlePreviewApproval = (session, text) => {
+  if (!/approve|looks good|confirm/i.test(text)) {
+    return {
+      messages: [
+        "Let me know once you approve the draft so I can create the final report."
+      ]
+    };
+  }
+
+  const validation = validateSessionData(session);
+  if (!validation.valid) {
+    return {
+      messages: [
+        "A validation check failed right before report generation:",
+        ...validation.issues
+      ]
+    };
+  }
+
+  const artifacts = generateReportArtifacts(session);
+  storeReportArtifacts(session.id, artifacts.pdfBuffer);
+
+  applyDataPatch(session, {
+    report: {
+      status: "draft",
+      doc_url: `/api/sessions/${session.id}/report.pdf`,
+      preview: artifacts.preview,
+      version: session.data.report.version,
+      signed_url: session.data.report.signed_url ?? null
+    }
+  });
+
+  return moveToStage(session, "S6_E_SIGNATURE", [
+    "I've generated your report. You can review it below and download the PDF when you're ready.",
+    "We'll keep the e-signature step static for now, but everything is ready for adviser review."
+  ]);
+};
+
+const handleESignature = () => ({
+  messages: [
+    "The report is available in your downloads. An adviser will trigger the e-signature request when appropriate."
+  ]
+});
+
+export const handleClientTurn = (session, text) => {
+  const stageHandlers = {
+    S0_CONSENT: handleConsent,
+    S1_IDENTITY_PROFILE: handleProfile,
+    S2_EDUCATION: handleEducation,
+    S3_PREFERENCE_CAPTURE: handlePreferenceCapture,
+    S4_ADVISER_VALIDATION: handleAdviserValidation,
+    S5_PREVIEW_APPROVAL: handlePreviewApproval,
+    S6_E_SIGNATURE: handleESignature,
+    S7_ARCHIVE: () => ({
+      messages: [
+        "This session is already archived. If you need changes, please start a new one."
+      ]
+    })
+  };
+
+  const handler = stageHandlers[session.stage] ?? (() => ({ messages: [] }));
+  const response = handler(session, text.trim());
+  saveSession(session);
+  return response;
+};
+
+export const handleAssistantMessage = (session, content) => {
+  applyDataPatch(session, content?.stageData ?? {});
+  saveSession(session);
+  return { messages: [] };
+};
+
+export const handleEvent = (session, event) => {
+  if (event.author === "client" && event.type === "message") {
+    return handleClientTurn(session, event.content?.text ?? "");
+  }
+
+  if (event.author === "assistant" && event.type === "message") {
+    return handleAssistantMessage(session, event.content ?? {});
+  }
+
+  return { messages: [] };
+};

--- a/server/state/sessionStore.js
+++ b/server/state/sessionStore.js
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+import { CONVERSATION_STAGES } from "./constants.js";
+
+const sessions = new Map();
+
+const createEmptySessionData = () => ({
+  client: null,
+  acknowledgements: null,
+  preferences: {
+    pathways: [],
+    ethical: {
+      enabled: false,
+      exclusions: []
+    },
+    stewardship: {
+      discretion: "fund_manager"
+    }
+  },
+  questionnaire_used: false,
+  products: [],
+  adviser_notes: "",
+  fees: {
+    bespoke: false,
+    explanation: ""
+  },
+  audit: {
+    events: [],
+    ip: null
+  },
+  report: {
+    version: "v1.0",
+    doc_url: null,
+    signed_url: null,
+    status: "draft",
+    preview: null
+  }
+});
+
+export const createSession = ({ ip } = {}) => {
+  const id = randomUUID();
+  const timestamp = new Date().toISOString();
+
+  const session = {
+    id,
+    stage: CONVERSATION_STAGES[0],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    data: createEmptySessionData(),
+    events: [],
+    context: {
+      profileStep: 0,
+      educationAcknowledged: false,
+      preference: {
+        allocationsCaptured: false,
+        needImpactThemes: false,
+        needEthicalDetail: false,
+        stewardshipAnswered: false
+      }
+    }
+  };
+
+  if (ip) {
+    session.data.audit.ip = ip;
+  }
+
+  sessions.set(id, session);
+  return session;
+};
+
+export const listSessions = () => Array.from(sessions.values());
+
+export const getSession = (id) => sessions.get(id) ?? null;
+
+const touchSession = (session) => {
+  session.updatedAt = new Date().toISOString();
+  return session;
+};
+
+export const saveSession = (session) => {
+  touchSession(session);
+  sessions.set(session.id, session);
+  return session;
+};
+
+export const setStage = (session, stage) => {
+  if (!CONVERSATION_STAGES.includes(stage)) {
+    return session;
+  }
+
+  session.stage = stage;
+  touchSession(session);
+  return session;
+};
+
+const deepMerge = (target, patch) => {
+  if (!patch || typeof patch !== "object") {
+    return target;
+  }
+
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      typeof target[key] === "object" &&
+      target[key] !== null &&
+      !Array.isArray(target[key])
+    ) {
+      deepMerge(target[key], value);
+    } else {
+      target[key] = structuredClone(value);
+    }
+  }
+
+  return target;
+};
+
+export const applyDataPatch = (session, patch) => {
+  if (!patch || typeof patch !== "object") {
+    return session;
+  }
+
+  deepMerge(session.data, patch);
+  touchSession(session);
+  return session;
+};
+
+export const appendEvent = (session, event) => {
+  session.events.push(event);
+  session.data.audit.events.push({
+    id: event.id,
+    author: event.author,
+    type: event.type,
+    createdAt: event.createdAt
+  });
+  touchSession(session);
+  return session;
+};
+
+export const toPublicSession = (session) => {
+  const clone = structuredClone(session);
+  return clone;
+};

--- a/server/state/validateSession.js
+++ b/server/state/validateSession.js
@@ -1,0 +1,139 @@
+import {
+  ATR_VALUES,
+  CFL_VALUES,
+  PATHWAY_NAMES,
+  STEWARDSHIP_OPTIONS
+} from "./constants.js";
+
+const uuidPattern =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
+
+const isNonEmptyString = (value) => typeof value === "string" && value.trim().length > 0;
+
+const isEmail = (value) =>
+  typeof value === "string" && /.+@.+\..+/.test(value.trim());
+
+const normaliseNumber = (value) => {
+  if (typeof value === "number") return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  }
+  return NaN;
+};
+
+export const validateSessionData = (session) => {
+  const issues = [];
+  const data = session?.data ?? {};
+
+  // Consent acknowledgement
+  if (!data.acknowledgements || data.acknowledgements.read_informed_choice !== true) {
+    issues.push("Client must confirm that they read and understood the explainer content.");
+  }
+
+  if (
+    data.acknowledgements &&
+    !isNonEmptyString(data.acknowledgements.timestamp)
+  ) {
+    issues.push("Consent acknowledgement requires an ISO timestamp.");
+  }
+
+  // Client profile
+  if (!data.client) {
+    issues.push("Client profile (name, contact, risk) is missing.");
+  } else {
+    if (!uuidPattern.test(data.client.id ?? "")) {
+      issues.push("Client ID must be a UUID.");
+    }
+    if (!isNonEmptyString(data.client.name)) {
+      issues.push("Client name is required.");
+    }
+    if (!data.client.contact || !isEmail(data.client.contact.email)) {
+      issues.push("Client email address is required.");
+    }
+    if (
+      !data.client.risk ||
+      !ATR_VALUES.includes(data.client.risk.atr) ||
+      !CFL_VALUES.includes(data.client.risk.cfl)
+    ) {
+      issues.push("Client risk profile must include ATR and CfL selections.");
+    }
+    const horizonYears = normaliseNumber(data.client.risk?.horizon_years);
+    if (!Number.isInteger(horizonYears) || horizonYears < 1) {
+      issues.push("Investment horizon must be a positive integer.");
+    }
+  }
+
+  // Preferences and allocations
+  const preferences = data.preferences ?? {};
+  const pathways = Array.isArray(preferences.pathways)
+    ? preferences.pathways
+    : [];
+
+  if (pathways.length === 0) {
+    issues.push("Select at least one Preference Pathway and allocation.");
+  }
+
+  const allocationTotal = pathways.reduce((sum, pathway) => {
+    const allocation = normaliseNumber(pathway.allocation_pct);
+    return sum + (Number.isFinite(allocation) ? allocation : 0);
+  }, 0);
+
+  if (Math.round(allocationTotal) !== 100) {
+    issues.push("Pathway allocations must add up to 100%.");
+  }
+
+  const sdgSensitivePathways = new Set([
+    "Sustainability: Focus",
+    "Sustainability: Impact",
+    "Sustainability: Mixed Goals"
+  ]);
+
+  pathways.forEach((pathway, index) => {
+    if (!PATHWAY_NAMES.includes(pathway.name)) {
+      issues.push(`Pathway at position ${index + 1} has an invalid name.`);
+    }
+    const allocation = normaliseNumber(pathway.allocation_pct);
+    if (!Number.isFinite(allocation) || allocation < 0 || allocation > 100) {
+      issues.push(`Allocation for ${pathway.name ?? "pathway"} must be between 0 and 100.`);
+    }
+
+    if (sdgSensitivePathways.has(pathway.name) && pathway.uses_sdgs) {
+      const hasThemes = Array.isArray(pathway.themes) && pathway.themes.length > 0;
+      const hasImpactGoals =
+        Array.isArray(pathway.impact_goals) && pathway.impact_goals.length > 0;
+      if (!hasThemes && !hasImpactGoals) {
+        issues.push(`Provide SDG themes or impact goals for ${pathway.name}.`);
+      }
+    }
+  });
+
+  if (preferences.ethical?.enabled) {
+    const exclusions = Array.isArray(preferences.ethical.exclusions)
+      ? preferences.ethical.exclusions.filter(isNonEmptyString)
+      : [];
+    if (exclusions.length === 0) {
+      issues.push("Ethical screens must include at least one exclusion when enabled.");
+    }
+  }
+
+  if (
+    preferences.stewardship &&
+    !STEWARDSHIP_OPTIONS.includes(preferences.stewardship.discretion)
+  ) {
+    issues.push("Stewardship discretion must be set to fund_manager or client_questionnaire.");
+  }
+
+  if (data.fees?.bespoke && !isNonEmptyString(data.fees.explanation)) {
+    issues.push("Provide a fee explanation whenever bespoke fees are flagged.");
+  }
+
+  if (!data.report || !isNonEmptyString(data.report.version)) {
+    issues.push("Report metadata must specify a version before generation.");
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues
+  };
+};


### PR DESCRIPTION
## Summary
- add a server-side conversation engine that interprets client replies, fills the SDR JSON payload, and triggers report creation
- generate in-memory PDF summaries with a dedicated download route while keeping artifacts accessible in session data
- refresh the browser UI and docs to surface dynamic prompts, live data, and the report preview/download experience

## Testing
- node server/server.js & curl -s -X POST http://localhost:4000/api/sessions; curl -s -X POST http://localhost:4000/api/sessions/$ID/events ...; curl -s http://localhost:4000/api/sessions/$ID/report.pdf; kill $SERVER_PID

------
https://chatgpt.com/codex/tasks/task_b_68d1cbafa7f48329940d0bc856f14850