### PR TITLE
feat: align chatbot flow with ESG suitability spec

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -204,8 +204,9 @@ const handleListCases = (res) => {
     id: session.id,
     stage: session.stage,
     updatedAt: session.updatedAt,
-    clientName: session.data.client?.name ?? null,
-    pathwayCount: session.data.preferences?.pathways?.length ?? 0
+    clientName: session.data.client_profile?.client_type ?? null,
+    pathwayCount:
+      session.data.sustainability_preferences?.labels_interest?.length ?? 0
   }));
 
   sendJSON(res, 200, { cases });
@@ -226,10 +227,24 @@ const handlePatchCase = async (req, res, id) => {
 
   const patch = {};
   if (typeof adviser_notes === "string") {
-    patch.adviser_notes = adviser_notes;
+    patch.advice_outcome = {
+      ...(patch.advice_outcome ?? {}),
+      adviser_notes
+    };
   }
   if (fees && typeof fees === "object") {
-    patch.fees = fees;
+    const feeDetails = {
+      bespoke: Boolean(fees.bespoke),
+      explanation: typeof fees.explanation === "string"
+        ? fees.explanation
+        : session.data.advice_outcome?.fee_details?.explanation ?? ""
+    };
+    patch.advice_outcome = {
+      ...(patch.advice_outcome ?? {}),
+      fee_details: feeDetails,
+      costs_summary:
+        feeDetails.explanation || session.data.advice_outcome?.costs_summary || ""
+    };
   }
   if (overrides && typeof overrides === "object") {
     Object.assign(patch, overrides);
@@ -243,7 +258,8 @@ const handlePatchCase = async (req, res, id) => {
     author: "adviser",
     type: "note",
     content: {
-      adviser_notes: adviser_notes ?? null
+      adviser_notes:
+        patch.advice_outcome?.adviser_notes ?? adviser_notes ?? null
     },
     createdAt: new Date().toISOString()
   });

--- a/server/spec/advice_session.schema.json
+++ b/server/spec/advice_session.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AdviceSession",
+  "type": "object",
+  "properties": {
+    "session_id": {"type": "string"},
+    "client_profile": {"type": "object"},
+    "sustainability_preferences": {"type": "object"},
+    "consent": {"type": "object"},
+    "summary_confirmation": {"type": "object"},
+    "advice_outcome": {"type": "object"},
+    "disclosures": {"type": "object"},
+    "prod_governance": {"type": "object"},
+    "timestamps": {"type": "object"},
+    "audit": {"type": "object"}
+  }
+}

--- a/server/spec/conversation_flow.md
+++ b/server/spec/conversation_flow.md
@@ -1,0 +1,88 @@
+# Conversation Flow Script (Segments A–H)
+
+## Segment A — Explanation
+Bot: "Welcome! I’ll guide you through ESG investing and collect the information your adviser needs to act in your best interests. I’ll explain plainly and send a summary at the end."
+Log: explanation_shown=true
+
+---
+
+## Segment B — Onboarding (Suitability Core)
+Questions (slots):
+1. client_type — "Are you investing as an individual, joint, trust, or company?"
+2. objectives — "What’s your main goal? (growth/income/preservation/impact/other)"
+3. horizon_years — "How long do you expect to keep this money invested?"
+4. risk_tolerance — "How comfortable are you with investment risk, from 1 (very low) to 7 (very high)?"
+5. capacity_for_loss — "If markets fall, how much loss could you afford without affecting your lifestyle?"
+6. liquidity_needs — "Will you need to withdraw funds at specific times?"
+7. knowledge_experience — "Have you invested before? Which instruments? How often? For how long?"
+8. financial_situation — "Would you like to record income, assets, and liabilities for context?"
+
+Validation rules:
+- Block progression if mandatory fields missing.
+- Warn if horizon <3y and risk ≥5.
+- If capacity_for_loss = low and risk ≥5 → require explicit override.
+
+---
+
+## Segment C — Consent
+Bot: "We need your permission to record your answers for regulatory reporting."
+1. consent.data_processing (Y/N + timestamp)
+2. consent.e_delivery (Y/N)
+3. consent.future_contact (Y/N, purpose)
+
+---
+
+## Segment D — Educational (ESG & SDR/AGR)
+Modules:
+1. What ESG means (factors, not a guarantee).
+2. SDR labels: Focus, Improvers, Impact, Mixed Goals.
+3. Anti-Greenwashing Rule: only evidence-backed claims.
+4. Product disclosures will always be attached.
+
+Comprehension check:
+Bot: "Would you like me to summarise the difference between Focus and Improvers?"
+Log: educ_pack_sent=true
+
+---
+
+## Segment E — Options & Labelling (KBS Pathway)
+Branching logic:
+- If preference_level=none → skip to summary.
+- If high_level → collect labels_interest[].
+- If detailed → collect labels_interest[], themes[], exclusions[], impact_goals, engagement_importance, reporting_frequency_pref, tradeoff_tolerance.
+
+Validations:
+- If Impact chosen → require impact_goals + reporting_frequency_pref != none.
+- If exclusions include fossil fuels → force numeric threshold.
+
+---
+
+## Segment F — Data Confirmation
+Bot: "Here’s what you told me..." [recap]
+User confirms (Yes/Edit).
+Store: summary_confirmation.client_summary_confirmed=true
+
+---
+
+## Segment G — Form Completion & Suitability Report
+- Map answers to KBS fields: client_profile, sustainability_preferences, advice_outcome, disclosures.
+- Auto-generate PDF report from suitability_report_template.md.
+- Store PDF hash + timestamp.
+
+---
+
+## Segment H — Delivery
+Bot: "I’ve prepared your personalised pack: (1) Summary of your needs, (2) Sustainability preferences, (3) FCA label explainer, (4) Next steps."
+Outputs:
+- Client Summary PDF
+- ESG & SDR explainer (KBS doc)
+- Disclosure bundle (product docs attached later)
+
+---
+
+# Compliance Guardrails
+- Consumer Duty: plain language + comprehension checks.
+- COBS 9A: suitability fields complete before recommendation.
+- PROD 3: target-market match required; block if insufficient manufacturer info.
+- Anti-Greenwashing: ESG claims gated by attached disclosures.
+- Audit trail: timestamps, policy version, evidence docs stored with hash.

--- a/server/spec/mi_dashboard_spec.md
+++ b/server/spec/mi_dashboard_spec.md
@@ -1,0 +1,21 @@
+# MI Dashboard Spec
+
+Datasets:
+- advice_session
+- sales
+- complaints
+- disclosures
+- product_catalogue
+
+KPIs:
+- % complete sessions
+- % outside target market
+- Complaint rates per 1,000
+- AGR guardrail trigger rates
+- Review timeliness
+
+Drilldowns:
+- Target-market heatmap
+- Greenwashing safeguards
+- Exclusions pressure map
+- Vulnerabilities lens

--- a/server/spec/nlu_spec.yaml
+++ b/server/spec/nlu_spec.yaml
@@ -1,0 +1,21 @@
+intents:
+  - name: capture_goal
+    examples: ["I want long-term growth", "Income focus"]
+  - name: capture_risk
+    examples: ["Medium risk", "Risk 5 out of 7"]
+  - name: capture_exclusions
+    examples: ["Exclude coal", "No tobacco"]
+
+entities:
+  - risk_level
+  - horizon_years
+  - label
+  - theme
+  - exclusion_sector
+  - threshold_value
+  - reporting_frequency
+
+validation_rules:
+  - rule: Require risk & horizon before recommendation
+  - rule: Require thresholds for exclusions
+  - rule: If Impact label chosen, require impact_goals

--- a/server/spec/suitability_report_template.md
+++ b/server/spec/suitability_report_template.md
@@ -1,0 +1,28 @@
+# Suitability Report Template
+
+## 1. Why we assessed your needs
+To act in your best interests, we gathered information about your goals, timeframe, risk tolerance and capacity for loss, financial position, knowledge and experience, and (where relevant) your sustainability preferences.
+
+## 2. Your goals and constraints
+Goal: {{client_profile.objectives}}
+Time horizon: {{client_profile.horizon_years}} years
+Risk tolerance: {{client_profile.risk_tolerance}} / 7
+Capacity for loss: {{client_profile.capacity_for_loss}}
+Liquidity needs: {{client_profile.liquidity_needs}}
+Knowledge/experience: {{client_profile.knowledge_experience.summary}}
+
+## 3. Your sustainability (ESG) preferences
+Preference level: {{sustainability_preferences.preference_level}}
+Label interest: {{sustainability_preferences.labels_interest}}
+Themes: {{sustainability_preferences.themes}}
+Exclusions & thresholds: {{sustainability_preferences.exclusions}}
+Impact goals: {{sustainability_preferences.impact_goals}}
+Engagement importance: {{sustainability_preferences.engagement_importance}}
+Reporting preference: {{sustainability_preferences.reporting_frequency_pref}}
+Trade-off tolerance: {{sustainability_preferences.tradeoff_tolerance}}
+
+## 4. Our recommendation and why it fits
+Recommendation: {{advice_outcome.recommendation}}
+How it meets your objectives and risk profile: {{advice_outcome.rationale}}
+How it reflects your sustainability preferences: {{advice_outcome.sust_fit}}
+Costs & charges summary: {{advice_outcome.costs_summary}}

--- a/server/state/constants.js
+++ b/server/state/constants.js
@@ -1,32 +1,54 @@
 export const CONVERSATION_STAGES = [
-  "S0_CONSENT",
-  "S1_IDENTITY_PROFILE",
-  "S2_EDUCATION",
-  "S3_PREFERENCE_CAPTURE",
-  "S4_ADVISER_VALIDATION",
-  "S5_PREVIEW_APPROVAL",
-  "S6_E_SIGNATURE",
-  "S7_ARCHIVE"
+  "SEGMENT_A_EXPLANATION",
+  "SEGMENT_B_ONBOARDING",
+  "SEGMENT_C_CONSENT",
+  "SEGMENT_D_EDUCATION",
+  "SEGMENT_E_OPTIONS",
+  "SEGMENT_F_CONFIRMATION",
+  "SEGMENT_G_REPORT",
+  "SEGMENT_H_DELIVERY",
+  "SEGMENT_COMPLETE"
 ];
 
 export const STAGE_PROMPTS = {
-  S0_CONSENT:
-    "Before we begin, please review our privacy disclosure and confirm that we may process your information.",
-  S1_IDENTITY_PROFILE:
-    "Let's capture your contact details, investment horizon, attitude to risk (ATR), and capacity for loss (CfL).",
-  S2_EDUCATION:
-    "Here is an overview of each Preference Pathway. Remember that there is no hierarchy between the strategies.",
-  S3_PREFERENCE_CAPTURE:
-    "Tell me which pathways you would like to pursue and how you would allocate percentages between them.",
-  S4_ADVISER_VALIDATION:
-    "An adviser will confirm that your selections align with your ATR, CfL, and product wrappers.",
-  S5_PREVIEW_APPROVAL:
-    "Please review the draft report before we request your signature.",
-  S6_E_SIGNATURE:
-    "We are preparing the documentation for e-signature.",
-  S7_ARCHIVE:
-    "All signed documents and transcripts are archived in line with our compliance policy."
+  SEGMENT_A_EXPLANATION:
+    "Welcome! I’ll guide you through ESG investing and collect the information your adviser needs. I’ll explain plainly and send a summary at the end. When you're ready, let me know and we'll begin.",
+  SEGMENT_B_ONBOARDING:
+    "Let's capture the core suitability information I need before any recommendation can be made.",
+  SEGMENT_C_CONSENT:
+    "Now I need to confirm your consent preferences for regulatory reporting.",
+  SEGMENT_D_EDUCATION:
+    "I'll walk you through the ESG education pack, including SDR labels and anti-greenwashing safeguards.",
+  SEGMENT_E_OPTIONS:
+    "Tell me about any sustainability options or labels you’re interested in so I can map them to FCA pathways.",
+  SEGMENT_F_CONFIRMATION:
+    "Please review and confirm the information you've provided.",
+  SEGMENT_G_REPORT:
+    "I'm preparing your personalised suitability pack based on everything you've shared.",
+  SEGMENT_H_DELIVERY:
+    "Here is your personalised pack, including your summary, sustainability preferences, label explainer and next steps.",
+  SEGMENT_COMPLETE:
+    "This session has been completed and archived. Start a new session if you need to make changes."
 };
+
+export const CLIENT_TYPES = ["individual", "joint", "trust", "company"];
+export const OBJECTIVE_OPTIONS = [
+  "growth",
+  "income",
+  "preservation",
+  "impact",
+  "other"
+];
+export const RISK_SCALE = [1, 2, 3, 4, 5, 6, 7];
+export const CAPACITY_FOR_LOSS_VALUES = ["low", "medium", "high"];
+
+export const PREFERENCE_LEVELS = ["none", "high_level", "detailed"];
+export const REPORTING_FREQUENCY_OPTIONS = [
+  "none",
+  "quarterly",
+  "semiannual",
+  "annual"
+];
 
 export const PATHWAY_NAMES = [
   "Conventional",
@@ -38,10 +60,6 @@ export const PATHWAY_NAMES = [
   "Ethical",
   "Philanthropy"
 ];
-
-export const ATR_VALUES = ["Cautious", "Balanced", "Adventurous"];
-export const CFL_VALUES = ["Low", "Medium", "High"];
-export const STEWARDSHIP_OPTIONS = ["fund_manager", "client_questionnaire"];
 
 export const EVENT_AUTHORS = [
   "client",

--- a/server/state/conversationEngine.js
+++ b/server/state/conversationEngine.js
@@ -1,8 +1,11 @@
 import {
-  ATR_VALUES,
-  CFL_VALUES,
+  CAPACITY_FOR_LOSS_VALUES,
+  CLIENT_TYPES,
+  OBJECTIVE_OPTIONS,
   PATHWAY_NAMES,
-  STEWARDSHIP_OPTIONS,
+  PREFERENCE_LEVELS,
+  REPORTING_FREQUENCY_OPTIONS,
+  RISK_SCALE,
   STAGE_PROMPTS
 } from "./constants.js";
 import {
@@ -14,22 +17,10 @@ import { validateSessionData } from "./validateSession.js";
 import { generateReportArtifacts } from "../report/reportGenerator.js";
 import { storeReportArtifacts } from "../report/reportStore.js";
 
-const yesPatterns = /\b(yes|yep|i (consent|agree|understand)|sure|ok(ay)?)\b/i;
+const yesPatterns = /\b(yes|yep|i (consent|agree|understand|accept)|sure|ok(ay)?|ready)\b/i;
+const noPatterns = /\b(no|nope|not (yet|now)|decline|refuse)\b/i;
 
 const normalise = (value) => value.trim().toLowerCase();
-
-const PATHWAY_MATCH_ORDER = [...PATHWAY_NAMES].sort(
-  (a, b) => b.length - a.length
-);
-
-const findPathwayByAlias = (fragment) => {
-  const normalised = normalise(fragment);
-  return (
-    PATHWAY_MATCH_ORDER.find((name) =>
-      normalised.includes(normalise(name))
-    ) ?? null
-  );
-};
 
 const splitList = (text) =>
   text
@@ -37,68 +28,36 @@ const splitList = (text) =>
     .map((item) => item.trim())
     .filter(Boolean);
 
-const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-const parseAllocations = (input) => {
-  const chunks = splitList(input.replace(/percent|%/gi, "%"));
-  const allocations = [];
-
-  for (const chunk of chunks) {
-    const percentMatch = chunk.match(/(-?\d{1,3})/);
-    if (!percentMatch) {
-      continue;
-    }
-
-    const percent = Number.parseInt(percentMatch[1], 10);
-    if (Number.isNaN(percent)) {
-      continue;
-    }
-
-    let pathway = findPathwayByAlias(chunk);
-    if (!pathway) {
-      for (const name of PATHWAY_NAMES) {
-        const pattern = new RegExp(escapeRegex(name), "i");
-        if (pattern.test(chunk)) {
-          pathway = name;
-          break;
-        }
-      }
-    }
-
-    if (!pathway) {
-      continue;
-    }
-
-    allocations.push({ name: pathway, allocation_pct: percent });
-  }
-
-  return allocations;
+const parseInteger = (value) => {
+  const parsed = Number.parseInt(value.trim(), 10);
+  return Number.isFinite(parsed) ? parsed : NaN;
 };
 
-const ensureClientShape = (session) => {
-  if (!session.data.client) {
-    session.data.client = {
-      id: session.data.client?.id ?? session.id,
-      name: "",
-      contact: { email: "", phone: "" },
-      risk: { atr: "", cfl: "", horizon_years: 0 }
-    };
-  }
-};
-
-const ensurePreferenceDefaults = (session) => {
-  if (!session.data.preferences) {
-    session.data.preferences = {
-      pathways: [],
-      ethical: { enabled: false, exclusions: [] },
-      stewardship: { discretion: "fund_manager" }
-    };
-  }
+const parseMoneyValue = (text, keyword) => {
+  const pattern = new RegExp(`${keyword}[^\n\r\d]*([\d,.]+)`, "i");
+  const match = text.match(pattern);
+  if (!match) return null;
+  const numeric = Number(match[1].replace(/,/g, ""));
+  return Number.isFinite(numeric) ? numeric : null;
 };
 
 const stageResponse = (session, stage, additionalMessages = []) => {
   if (session.stage !== stage) {
     setStage(session, stage);
+  }
+
+  if (
+    stage === "SEGMENT_A_EXPLANATION" &&
+    !session.data.audit.explanation_shown
+  ) {
+    applyDataPatch(session, {
+      audit: {
+        explanation_shown: true
+      },
+      timestamps: {
+        explanation_shown_at: new Date().toISOString()
+      }
+    });
   }
 
   const prompt = STAGE_PROMPTS[stage];
@@ -111,396 +70,782 @@ const moveToStage = (session, stage, extraMessages = []) => {
   return { messages };
 };
 
-const handleConsent = (session, text) => {
+const ensureArray = (value) => (Array.isArray(value) ? value : []);
+
+const parseExclusions = (input) => {
+  if (/\b(none|no exclusions)\b/i.test(input)) {
+    return [];
+  }
+
+  return splitList(input).map((item) => {
+    const match = item.match(/(-?\d+(?:\.\d+)?)%?/);
+    const threshold = match ? Number.parseFloat(match[1]) : null;
+    const sector = item.replace(/(-?\d+(?:\.\d+)?)%?/g, "").trim();
+    return {
+      sector: sector || item.trim(),
+      threshold
+    };
+  });
+};
+
+const last = (items, predicate) => {
+  for (let i = items.length - 1; i >= 0; i -= 1) {
+    if (predicate(items[i])) return items[i];
+  }
+  return null;
+};
+
+const handleExplanation = (session, text) => {
   if (!yesPatterns.test(text)) {
     return {
       messages: [
-        "I need your explicit consent to continue. Please reply with 'Yes' if you agree to proceed." 
+        "When you're ready to continue, reply with 'Ready' or 'Yes' so I can start the onboarding questions."
       ]
     };
   }
 
-  applyDataPatch(session, {
-    acknowledgements: {
-      read_informed_choice: false,
-      timestamp: new Date().toISOString()
-    },
-    audit: {
-      events: session.data.audit.events,
-      ip: session.data.audit.ip
-    }
-  });
-
-  session.context.profileStep = 0;
-
-  return moveToStage(session, "S1_IDENTITY_PROFILE", [
-    "Thank you. Let's begin with a few details about you.",
-    "What is your full name?"
+  session.context.onboardingStep = 0;
+  return moveToStage(session, "SEGMENT_B_ONBOARDING", [
+    "Are you investing as an individual, joint, trust, or company?"
   ]);
 };
 
-const handleProfile = (session, text) => {
-  ensureClientShape(session);
-  const client = session.data.client;
-  const step = session.context.profileStep ?? 0;
+const handleRiskOverride = (session, text) => {
+  if (!session.context.requireRiskOverride) {
+    return null;
+  }
+
+  if (!yesPatterns.test(text) && !/accept|proceed|override/i.test(text)) {
+    return {
+      messages: [
+        "Please explicitly confirm that you wish to proceed with a higher risk tolerance despite indicating a low capacity for loss."
+      ]
+    };
+  }
+
+  session.context.requireRiskOverride = false;
+  const guardrail = last(
+    ensureArray(session.data.audit.guardrail_triggers),
+    (item) => item?.type === "risk_capacity_override" && !item?.confirmed_at
+  );
+  if (guardrail) {
+    guardrail.confirmed_at = new Date().toISOString();
+  }
+
+  session.context.onboardingStep = Math.max(session.context.onboardingStep, 5);
+  return {
+    messages: [
+      "Thank you for confirming. Will you need to withdraw funds at specific times?"
+    ]
+  };
+};
+
+const handleOnboarding = (session, text) => {
+  const overrideResult = handleRiskOverride(session, text);
+  if (overrideResult) {
+    return overrideResult;
+  }
+
+  const profile = session.data.client_profile;
+  const step = session.context.onboardingStep ?? 0;
+  const responses = [];
 
   if (step === 0) {
-    client.name = text.trim();
-    session.context.profileStep = 1;
-    saveSession(session);
-    return { messages: ["Thanks, " + client.name + ". What is your email address?"] };
+    const choice = CLIENT_TYPES.find(
+      (type) => normalise(type) === normalise(text)
+    );
+    if (!choice) {
+      return {
+        messages: [
+          "Please choose from individual, joint, trust, or company so I can log the correct client type."
+        ]
+      };
+    }
+
+    profile.client_type = choice;
+    session.context.onboardingStep = 1;
+    return {
+      messages: [
+        "Thanks. What’s your main investment goal? (growth, income, preservation, impact, or other)"
+      ]
+    };
   }
 
   if (step === 1) {
-    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailPattern.test(text.trim())) {
-      return { messages: ["That email doesn't look valid. Could you double-check and resend it?"] };
-    }
-    client.contact.email = text.trim();
-    session.context.profileStep = 2;
-    saveSession(session);
+    const raw = text.trim();
+    const option = OBJECTIVE_OPTIONS.find(
+      (item) => normalise(item) === normalise(raw)
+    );
+    profile.objectives = option ?? raw;
+    session.context.onboardingStep = 2;
     return {
       messages: [
-        "Got it. Which attitude to risk (ATR) best describes you? Choose from: " +
-          ATR_VALUES.join(", ") + "."
+        "How long do you expect to keep this money invested? Please provide the number of years."
       ]
     };
   }
 
   if (step === 2) {
-    const choice = ATR_VALUES.find(
-      (value) => normalise(value) === normalise(text)
-    );
-    if (!choice) {
+    const years = parseInteger(text);
+    if (!Number.isInteger(years) || years <= 0) {
       return {
         messages: [
-          "Please choose one of the ATR options: " + ATR_VALUES.join(", ") + "."
+          "Please provide your investment horizon as a positive whole number of years."
         ]
       };
     }
-    client.risk.atr = choice;
-    session.context.profileStep = 3;
-    saveSession(session);
+
+    profile.horizon_years = years;
+    session.context.onboardingStep = 3;
     return {
       messages: [
-        "Thank you. What is your capacity for loss (CfL)? Options: " +
-          CFL_VALUES.join(", ") + "."
+        "On a scale of 1 (very low) to 7 (very high), how comfortable are you with investment risk?"
       ]
     };
   }
 
   if (step === 3) {
-    const choice = CFL_VALUES.find(
+    const risk = parseInteger(text);
+    if (!RISK_SCALE.includes(risk)) {
+      return {
+        messages: [
+          "Please choose a risk level from 1 to 7, where 1 is very low risk and 7 is very high risk."
+        ]
+      };
+    }
+
+    profile.risk_tolerance = risk;
+    if (profile.horizon_years && profile.horizon_years < 3 && risk >= 5) {
+      session.data.audit.guardrail_triggers.push({
+        type: "risk_horizon_warning",
+        triggered_at: new Date().toISOString(),
+        notes: "High risk with short horizon"
+      });
+      responses.push(
+        "⚠️ You’ve chosen a high risk level with a short time horizon. I’ll highlight this for your adviser so they can discuss whether it remains suitable."
+      );
+    }
+
+    session.context.onboardingStep = 4;
+    responses.push(
+      "If markets fall, how much loss could you afford without affecting your lifestyle? (low, medium, high)"
+    );
+    return { messages: responses };
+  }
+
+  if (step === 4) {
+    const choice = CAPACITY_FOR_LOSS_VALUES.find(
       (value) => normalise(value) === normalise(text)
     );
     if (!choice) {
       return {
         messages: [
-          "Please choose one of the CfL options: " + CFL_VALUES.join(", ") + "."
+          "Please let me know if your capacity for loss is low, medium, or high."
         ]
       };
     }
-    client.risk.cfl = choice;
-    session.context.profileStep = 4;
-    saveSession(session);
-    return {
-      messages: [
-        "Understood. What is your investment horizon in years? (Please enter a number.)"
-      ]
-    };
-  }
 
-  if (step === 4) {
-    const years = Number.parseInt(text.trim(), 10);
-    if (!Number.isFinite(years) || years <= 0) {
+    profile.capacity_for_loss = choice;
+    session.context.onboardingStep = 5;
+
+    if (profile.risk_tolerance >= 5 && choice === "low") {
+      session.context.requireRiskOverride = true;
+      session.data.audit.guardrail_triggers.push({
+        type: "risk_capacity_override",
+        triggered_at: new Date().toISOString(),
+        confirmed_at: null
+      });
       return {
-        messages: ["Please provide the number of years as a positive whole number."]
+        messages: [
+          "Because you’ve selected a high risk tolerance but a low capacity for loss, please explicitly confirm you wish to proceed with that combination."
+        ]
       };
     }
-    client.risk.horizon_years = years;
-    session.context.profileStep = 5;
-    saveSession(session);
+
     return {
       messages: [
-        "Thanks. Which product wrappers are you considering? (For example: ISA, Pension)."
+        "Will you need to withdraw funds at specific times?"
       ]
     };
   }
 
   if (step === 5) {
-    const wrappers = splitList(text);
-    applyDataPatch(session, {
-      products: wrappers.map((wrapper) => ({ wrapper }))
-    });
-    session.context.profileStep = 6;
-    session.context.educationAcknowledged = false;
+    profile.liquidity_needs = text.trim();
+    session.context.onboardingStep = 6;
+    return {
+      messages: [
+        "Have you invested before? Please describe which instruments, how often, and for how long."
+      ]
+    };
+  }
 
-    return moveToStage(session, "S2_EDUCATION", [
-      "Great. Here's a quick overview of each pathway: Conventional, Conventional incl. ESG, Improvers, Focus, Impact, Mixed Goals, Ethical, and Philanthropy. None is ranked above the others—they simply suit different objectives.",
-      "Please confirm once you've read this summary so we can record your informed choice acknowledgment."
+  if (step === 6) {
+    profile.knowledge_experience.summary = text.trim();
+    profile.knowledge_experience.instruments = splitList(text);
+    profile.knowledge_experience.frequency = /monthly|quarterly|annual|weekly/i.test(text)
+      ? (text.match(/(daily|weekly|monthly|quarterly|annual)/i)?.[1] ?? "")
+      : "";
+    profile.knowledge_experience.duration = text.match(/\b(\d+\s*(years?|months?))\b/i)?.[0] ?? "";
+    session.context.onboardingStep = 7;
+    return {
+      messages: [
+        "Would you like to record income, assets, and liabilities for context?"
+      ]
+    };
+  }
+
+  if (step === 7) {
+    if (noPatterns.test(text)) {
+      profile.financial_situation = {
+        provided: false,
+        income: null,
+        assets: null,
+        liabilities: null,
+        notes: ""
+      };
+      session.context.onboardingStep = 9;
+      session.context.consentStep = 0;
+      return moveToStage(session, "SEGMENT_C_CONSENT", [
+        "We need your permission to record your answers for regulatory reporting.",
+        "Do you consent to us processing your data for this advice session?"
+      ]);
+    }
+
+    if (!yesPatterns.test(text)) {
+      return {
+        messages: [
+          "Please let me know 'Yes' or 'No' so I can record whether to capture your financial details."
+        ]
+      };
+    }
+
+    profile.financial_situation.provided = true;
+    session.context.onboardingStep = 8;
+    return {
+      messages: [
+        "Please share any income, assets, and liabilities you’d like recorded (for example: Income £60k, Assets £250k, Liabilities £40k)."
+      ]
+    };
+  }
+
+  if (step === 8) {
+    const details = text.trim();
+    if (!details) {
+      return {
+        messages: [
+          "Could you provide a short summary of your income, assets, and liabilities?"
+        ]
+      };
+    }
+
+    profile.financial_situation.notes = details;
+    profile.financial_situation.income = parseMoneyValue(details, "income");
+    profile.financial_situation.assets = parseMoneyValue(details, "asset");
+    profile.financial_situation.liabilities = parseMoneyValue(details, "liabilit");
+    session.context.onboardingStep = 9;
+    session.context.consentStep = 0;
+    return moveToStage(session, "SEGMENT_C_CONSENT", [
+      "Thank you. We need your permission to record your answers for regulatory reporting.",
+      "Do you consent to us processing your data for this advice session?"
     ]);
   }
 
-  return { messages: ["Let me summarise before we continue."] };
+  return {
+    messages: [
+      "Let me summarise before we continue."
+    ]
+  };
+};
+
+const handleConsent = (session, text) => {
+  const consent = session.data.consent;
+  const step = session.context.consentStep ?? 0;
+
+  if (step === 0) {
+    if (!yesPatterns.test(text)) {
+      return {
+        messages: [
+          "I’m unable to proceed without your consent to process this information. Please reply 'Yes' if you agree."
+        ]
+      };
+    }
+
+    const timestamp = new Date().toISOString();
+    consent.data_processing = { granted: true, timestamp };
+    session.data.timestamps.consent_recorded_at = timestamp;
+    session.context.consentStep = 1;
+    return {
+      messages: [
+        "Thank you. Do you consent to receive documents electronically (e-delivery)?"
+      ]
+    };
+  }
+
+  if (step === 1) {
+    const granted = yesPatterns.test(text) ? true : noPatterns.test(text) ? false : null;
+    if (granted === null) {
+      return {
+        messages: [
+          "Please reply with 'Yes' or 'No' so I can record your e-delivery preference."
+        ]
+      };
+    }
+
+    consent.e_delivery = {
+      granted,
+      timestamp: new Date().toISOString()
+    };
+    session.context.consentStep = 2;
+    return {
+      messages: [
+        "Can we contact you in the future with relevant updates?"
+      ]
+    };
+  }
+
+  if (step === 2) {
+    if (noPatterns.test(text)) {
+      consent.future_contact = { granted: false, purpose: "" };
+      session.context.consentStep = 4;
+      return moveToStage(session, "SEGMENT_D_EDUCATION", [
+        "Here’s a quick ESG education pack covering key regulatory points:",
+        "• ESG stands for Environmental, Social, and Governance – it highlights factors, not guaranteed outcomes.",
+        "• UK SDR labels include Focus, Improvers, Impact, and Mixed Goals.",
+        "• The Anti-Greenwashing Rule means we only make evidence-backed sustainability claims.",
+        "• Product disclosures will always be attached for you to review.",
+        "Reply 'Understood' when you’re ready to continue."
+      ]);
+    }
+
+    if (!yesPatterns.test(text)) {
+      return {
+        messages: [
+          "Please let me know 'Yes' or 'No' so I can record your future contact preference."
+        ]
+      };
+    }
+
+    consent.future_contact = { granted: true, purpose: "" };
+    session.context.consentStep = 3;
+    return {
+      messages: [
+        "Thanks. What purpose should we note for future contact (for example, annual review or product updates)?"
+      ]
+    };
+  }
+
+  if (step === 3) {
+    consent.future_contact.purpose = text.trim();
+    session.context.consentStep = 4;
+    return moveToStage(session, "SEGMENT_D_EDUCATION", [
+      "Here’s a quick ESG education pack covering key regulatory points:",
+      "• ESG stands for Environmental, Social, and Governance – it highlights factors, not guaranteed outcomes.",
+      "• UK SDR labels include Focus, Improvers, Impact, and Mixed Goals.",
+      "• The Anti-Greenwashing Rule means we only make evidence-backed sustainability claims.",
+      "• Product disclosures will always be attached for you to review.",
+      "Reply 'Understood' when you’re ready to continue."
+    ]);
+  }
+
+  return { messages: [] };
 };
 
 const handleEducation = (session, text) => {
-  if (!yesPatterns.test(text)) {
-    return {
-      messages: [
-        "Take your time. When you're ready, reply with 'I understand' so I can log your acknowledgment."
-      ]
-    };
-  }
-
-  applyDataPatch(session, {
-    acknowledgements: {
-      read_informed_choice: true,
-      timestamp: new Date().toISOString()
-    }
-  });
-
-  session.context.preference = {
-    allocationsCaptured: false,
-    needImpactThemes: false,
-    needEthicalDetail: false,
-    stewardshipAnswered: false
+  const education = session.context.education ?? {
+    acknowledged: false,
+    summaryOffered: false,
+    summarised: false
   };
 
-  return moveToStage(session, "S3_PREFERENCE_CAPTURE", [
-    "Which pathways would you like to select and how would you allocate percentages between them? You can reply for example: 'Focus 50%, Impact 30%, Conventional incl. ESG 20%'."
-  ]);
-};
-
-const applyPreferenceAllocations = (session, allocations) => {
-  ensurePreferenceDefaults(session);
-  const unique = new Map();
-  for (const allocation of allocations) {
-    unique.set(allocation.name, allocation);
-  }
-  session.data.preferences.pathways = Array.from(unique.values());
-};
-
-const handlePreferenceCapture = (session, text) => {
-  ensurePreferenceDefaults(session);
-  const prefContext = session.context.preference ?? {
-    allocationsCaptured: false,
-    needImpactThemes: false,
-    needEthicalDetail: false,
-    stewardshipAnswered: false
-  };
-
-  if (!prefContext.allocationsCaptured) {
-    const allocations = parseAllocations(text);
-    const total = allocations.reduce((sum, item) => sum + item.allocation_pct, 0);
-
-    if (allocations.length === 0 || total !== 100) {
+  if (!education.acknowledged) {
+    if (!yesPatterns.test(text)) {
       return {
         messages: [
-          "I couldn't record that. Please list each pathway with its percentage so the total equals 100."
+          "Take your time reviewing the education pack. Reply with 'Understood' once you’re ready to continue."
         ]
       };
     }
 
-    applyPreferenceAllocations(session, allocations);
-
-    prefContext.allocationsCaptured = true;
-    prefContext.needImpactThemes = session.data.preferences.pathways.some((pathway) =>
-      [
-        "Sustainability: Focus",
-        "Sustainability: Impact",
-        "Sustainability: Mixed Goals"
-      ].includes(pathway.name)
-    );
-    prefContext.needEthicalDetail = session.data.preferences.pathways.some(
-      (pathway) => pathway.name === "Ethical"
-    );
-
-    session.context.preference = prefContext;
+    education.acknowledged = true;
+    education.summaryOffered = true;
+    session.data.sustainability_preferences.educ_pack_sent = true;
+    session.data.audit.educ_pack_sent = true;
+    session.data.disclosures.agr_disclaimer_presented = true;
+    session.data.timestamps.education_completed_at = new Date().toISOString();
+    session.context.education = education;
     saveSession(session);
-
-    if (prefContext.needImpactThemes) {
-      return {
-        messages: [
-          "Thanks. Which SDG themes or impact goals should we highlight for your Focus/Impact/Mixed Goals pathways?"
-        ]
-      };
-    }
-
-    if (prefContext.needEthicalDetail) {
-      return {
-        messages: [
-          "Please list any ethical screens, inclusions, or exclusions you'd like noted."
-        ]
-      };
-    }
-
     return {
       messages: [
-        "Would you like to leave stewardship discretion with the fund manager or complete a questionnaire yourself?"
+        "Would you like me to summarise the difference between Focus and Improvers labels?"
       ]
     };
   }
 
-  if (prefContext.needImpactThemes) {
-    const items = splitList(text);
-    for (const pathway of session.data.preferences.pathways) {
-      if (pathway.name === "Sustainability: Focus") {
-        pathway.themes = items;
-        pathway.uses_sdgs = true;
-      }
-      if (pathway.name === "Sustainability: Impact") {
-        pathway.impact_goals = items;
-        pathway.uses_sdgs = true;
-      }
-      if (pathway.name === "Sustainability: Mixed Goals") {
-        pathway.themes = items;
-        pathway.impact_goals = items;
-        pathway.uses_sdgs = true;
-      }
+  if (education.summaryOffered && !education.summarised) {
+    if (yesPatterns.test(text)) {
+      education.summarised = true;
+      session.context.education = education;
+      return moveToStage(session, "SEGMENT_E_OPTIONS", [
+        "Focus funds invest in companies already leading on sustainability factors, whereas Improvers target companies with credible plans to improve.",
+        "Do you have sustainability preferences? Choose from: none, high_level, or detailed."
+      ]);
     }
-    prefContext.needImpactThemes = false;
-    session.context.preference = prefContext;
-    saveSession(session);
 
-    if (prefContext.needEthicalDetail) {
+    if (!noPatterns.test(text)) {
       return {
         messages: [
-          "Noted. Please list any ethical screens, inclusions, or exclusions you'd like documented."
+          "Please reply with 'Yes' if you’d like the summary or 'No' if you’re happy to move on."
         ]
       };
     }
 
-    return {
-      messages: [
-        "Would you like to leave stewardship discretion with the fund manager or complete a questionnaire yourself?"
-      ]
-    };
-  }
-
-  if (prefContext.needEthicalDetail) {
-    const noPreference = /\b(no|none|not at this time)\b/i;
-    if (noPreference.test(text)) {
-      session.data.preferences.ethical = {
-        enabled: false,
-        exclusions: []
-      };
-    } else {
-      session.data.preferences.ethical = {
-        enabled: true,
-        exclusions: splitList(text)
-      };
-    }
-    prefContext.needEthicalDetail = false;
-    session.context.preference = prefContext;
-    saveSession(session);
-
-    return {
-      messages: [
-        "Would you like to leave stewardship discretion with the fund manager or complete a questionnaire yourself?"
-      ]
-    };
-  }
-
-  if (!prefContext.stewardshipAnswered) {
-    const answer = normalise(text);
-    const option = STEWARDSHIP_OPTIONS.find((item) => answer.includes(item.replace("_", " ")));
-
-    if (!option) {
-      return {
-        messages: [
-          "Please let me know if the discretion should stay with the fund manager or if you'd prefer to complete a questionnaire."
-        ]
-      };
-    }
-
-    session.data.preferences.stewardship = { discretion: option };
-    session.context.preference.stewardshipAnswered = true;
-    session.context.preference.allocationsCaptured = true;
-    session.context.preference.needEthicalDetail = false;
-    session.context.preference.needImpactThemes = false;
-
-    return moveToStage(session, "S4_ADVISER_VALIDATION", [
-      "Perfect. I'll package this for your adviser to review the suitability narrative.",
-      "When you're ready, type 'preview' and I'll build a draft report for you to check before signature."
+    education.summarised = true;
+    session.context.education = education;
+    return moveToStage(session, "SEGMENT_E_OPTIONS", [
+      "No problem. Do you have sustainability preferences? Choose from: none, high_level, or detailed."
     ]);
   }
 
-  return { messages: ["Let me know when you'd like the preview."] };
+  return {
+    messages: [
+      "Let’s capture your sustainability preferences."
+    ]
+  };
 };
 
-const summarisePreferences = (session) => {
-  const lines = [];
-  const clientName = session.data.client?.name ?? "Client";
-  lines.push(`Preference Pathway Summary for ${clientName}`);
-  lines.push("Allocations:");
-  for (const pathway of session.data.preferences.pathways) {
-    const details = [];
-    if (pathway.themes?.length) {
-      details.push(`Themes: ${pathway.themes.join(", ")}`);
+const impactChosen = (labels) =>
+  ensureArray(labels).some((label) => /impact/i.test(label));
+
+const parseLabels = (text) =>
+  splitList(text).map((label) => {
+    const match = PATHWAY_NAMES.find((name) =>
+      normalise(name).includes(normalise(label)) ||
+      normalise(label).includes(normalise(name))
+    );
+    return match ?? label.trim();
+  });
+
+const handleOptions = (session, text) => {
+  const prefs = session.data.sustainability_preferences;
+  const optionsContext = session.context.options ?? {
+    preferenceLevel: null,
+    step: 0,
+    pendingExclusions: false,
+    pendingImpactDetails: false
+  };
+
+  if (!optionsContext.preferenceLevel) {
+    const choice = PREFERENCE_LEVELS.find(
+      (item) => normalise(item) === normalise(text)
+    );
+    if (!choice) {
+      return {
+        messages: [
+          "Please choose from: none, high_level, or detailed."
+        ]
+      };
     }
-    if (pathway.impact_goals?.length) {
-      details.push(`Impact goals: ${pathway.impact_goals.join(", ")}`);
+
+    prefs.preference_level = choice;
+    optionsContext.preferenceLevel = choice;
+    session.context.options = optionsContext;
+
+    if (choice === "none") {
+      prefs.labels_interest = [];
+      prefs.themes = [];
+      prefs.exclusions = [];
+      prefs.impact_goals = [];
+      prefs.engagement_importance = "";
+      prefs.reporting_frequency_pref = "none";
+      prefs.tradeoff_tolerance = "";
+      return moveToStage(session, "SEGMENT_F_CONFIRMATION", [
+        "I’ll note that you have no specific sustainability preferences. I’ll summarise everything next."
+      ]);
     }
-    lines.push(`- ${pathway.name}: ${pathway.allocation_pct}%${
-      details.length ? ` (${details.join("; ")})` : ""
-    }`);
+
+    optionsContext.step = 1;
+    saveSession(session);
+    return {
+      messages: [
+        "Which FCA SDR labels interest you?"
+      ]
+    };
   }
-  if (session.data.preferences.ethical?.enabled) {
+
+  const step = optionsContext.step ?? 0;
+
+  if (step === 1) {
+    const labels = parseLabels(text);
+    if (labels.length === 0) {
+      return {
+        messages: [
+          "Please list at least one label or say 'none' if you wish to skip."
+        ]
+      };
+    }
+    prefs.labels_interest = labels;
+
+    if (optionsContext.preferenceLevel === "high_level") {
+      return moveToStage(session, "SEGMENT_F_CONFIRMATION", [
+        "Thanks, I’ve noted those label interests. I’ll recap everything for you now."
+      ]);
+    }
+
+    optionsContext.step = 2;
+    session.context.options = optionsContext;
+    return {
+      messages: [
+        "Are there particular sustainability themes you want to focus on? (e.g. climate, biodiversity, social equity)"
+      ]
+    };
+  }
+
+  if (step === 2) {
+    prefs.themes = /\b(none|not at this time)\b/i.test(text)
+      ? []
+      : splitList(text);
+    optionsContext.step = 3;
+    session.context.options = optionsContext;
+    return {
+      messages: [
+        "Please list any exclusions and thresholds (for example: Fossil fuels under 5%, Tobacco 0%)."
+      ]
+    };
+  }
+
+  if (step === 3) {
+    const exclusions = parseExclusions(text);
+    const fossil = exclusions.find((item) => /fossil/i.test(item.sector));
+    if (fossil && (fossil.threshold === null || Number.isNaN(fossil.threshold))) {
+      return {
+        messages: [
+          "For fossil fuels, please provide a numeric threshold (for example: Fossil fuels under 5%)."
+        ]
+      };
+    }
+
+    prefs.exclusions = exclusions.map((item) => ({
+      sector: item.sector,
+      threshold: item.threshold
+    }));
+    optionsContext.step = 4;
+    session.context.options = optionsContext;
+    return {
+      messages: [
+        "Do you have any specific impact goals (for example: SDG 7 affordable clean energy)?"
+      ]
+    };
+  }
+
+  if (step === 4) {
+    if (impactChosen(prefs.labels_interest) && /\b(none|not at this time)\b/i.test(text)) {
+      return {
+        messages: [
+          "Impact-labelled investments require at least one goal. Please list the outcomes that matter to you."
+        ]
+      };
+    }
+
+    prefs.impact_goals = /\b(none|not at this time)\b/i.test(text)
+      ? []
+      : splitList(text);
+    optionsContext.step = 5;
+    session.context.options = optionsContext;
+    return {
+      messages: [
+        "How important is active stewardship or engagement from managers?"
+      ]
+    };
+  }
+
+  if (step === 5) {
+    prefs.engagement_importance = text.trim();
+    optionsContext.step = 6;
+    session.context.options = optionsContext;
+    return {
+      messages: [
+        "How often would you like sustainability reporting updates? (none, quarterly, semiannual, annual)"
+      ]
+    };
+  }
+
+  if (step === 6) {
+    const choice = REPORTING_FREQUENCY_OPTIONS.find(
+      (value) => normalise(value) === normalise(text)
+    );
+    if (!choice) {
+      return {
+        messages: [
+          "Please choose a reporting frequency: none, quarterly, semiannual, or annual."
+        ]
+      };
+    }
+
+    if (impactChosen(prefs.labels_interest) && choice === "none") {
+      return {
+        messages: [
+          "Impact-focused solutions require a reporting preference so we can evidence outcomes. Please choose quarterly, semiannual, or annual."
+        ]
+      };
+    }
+
+    prefs.reporting_frequency_pref = choice;
+    optionsContext.step = 7;
+    session.context.options = optionsContext;
+    return {
+      messages: [
+        "How much investment performance trade-off are you willing to accept for sustainability outcomes?"
+      ]
+    };
+  }
+
+  if (step === 7) {
+    prefs.tradeoff_tolerance = text.trim();
+    session.context.options = optionsContext;
+    return moveToStage(session, "SEGMENT_F_CONFIRMATION", [
+      "Thanks, I’ve captured those details. Let me summarise everything back to you."
+    ]);
+  }
+
+  return { messages: [] };
+};
+
+const buildSummary = (session) => {
+  const profile = session.data.client_profile;
+  const prefs = session.data.sustainability_preferences;
+  const consent = session.data.consent;
+
+  const lines = [];
+  lines.push("Here’s what you told me:");
+  lines.push(
+    `• Client type: ${profile.client_type}`
+  );
+  lines.push(
+    `• Objectives: ${profile.objectives}`
+  );
+  lines.push(
+    `• Horizon: ${profile.horizon_years ?? "—"} years`
+  );
+  lines.push(
+    `• Risk tolerance: ${profile.risk_tolerance} / 7`
+  );
+  lines.push(
+    `• Capacity for loss: ${profile.capacity_for_loss}`
+  );
+  lines.push(
+    `• Liquidity needs: ${profile.liquidity_needs}`
+  );
+  lines.push(
+    `• Knowledge & experience: ${profile.knowledge_experience.summary}`
+  );
+  if (profile.financial_situation.provided) {
     lines.push(
-      `Ethical exclusions: ${session.data.preferences.ethical.exclusions.join(", ")}`
+      `• Financial context: ${profile.financial_situation.notes}`
+    );
+  }
+  if (prefs.preference_level !== "none") {
+    lines.push(
+      `• Sustainability preference level: ${prefs.preference_level}`
+    );
+    lines.push(
+      `• Label interests: ${prefs.labels_interest.join(", ") || "None"}`
+    );
+    if (prefs.themes.length) {
+      lines.push(`• Themes: ${prefs.themes.join(", ")}`);
+    }
+    if (prefs.exclusions.length) {
+      lines.push(
+        `• Exclusions: ${prefs.exclusions
+          .map((item) =>
+            item.threshold != null
+              ? `${item.sector} (<${item.threshold}%)`
+              : item.sector
+          )
+          .join(", ")}`
+      );
+    }
+    if (prefs.impact_goals.length) {
+      lines.push(`• Impact goals: ${prefs.impact_goals.join(", ")}`);
+    }
+    lines.push(
+      `• Engagement importance: ${prefs.engagement_importance || "Not specified"}`
+    );
+    lines.push(
+      `• Reporting frequency preference: ${prefs.reporting_frequency_pref}`
+    );
+    lines.push(
+      `• Trade-off tolerance: ${prefs.tradeoff_tolerance || "Not specified"}`
     );
   }
   lines.push(
-    `Stewardship discretion: ${session.data.preferences.stewardship?.discretion}`
+    `• Consent to data processing recorded: ${consent.data_processing?.granted ? "Yes" : "No"}`
   );
   return lines.join("\n");
 };
 
-const handleAdviserValidation = (session, text) => {
-  if (!/preview|ready|build/i.test(text)) {
+const handleConfirmation = (session, text) => {
+  if (!session.context.confirmationAwaiting) {
+    session.context.confirmationAwaiting = true;
     return {
       messages: [
-        "Once you're ready for the preview, reply with 'Preview' or 'Ready'."
+        buildSummary(session),
+        "Is this correct? Reply 'Yes' to confirm or tell me what needs updating."
       ]
     };
   }
 
-  const validation = validateSessionData(session);
-  if (!validation.valid) {
+  if (!yesPatterns.test(text)) {
+    if (/edit|change|update/i.test(text)) {
+      return {
+        messages: [
+          "Please let me know the details that need updating and an adviser will follow up, or restart the session to re-run the questionnaire."
+        ]
+      };
+    }
+
     return {
       messages: [
-        "We're missing a few details before I can produce the report:",
-        ...validation.issues
+        "I’ll need a 'Yes' to confirm accuracy. If anything is incorrect, please tell me what should be amended."
       ]
     };
   }
 
-  session.data.adviser_notes =
-    session.data.adviser_notes ||
-    `Session ${session.id} auto-generated narrative. ATR ${session.data.client?.risk?.atr}, CfL ${session.data.client?.risk?.cfl}.`;
-
-  return moveToStage(session, "S5_PREVIEW_APPROVAL", [
-    "Here's a summary of what we've captured:",
-    summarisePreferences(session),
-    "Reply with 'Approve' when this looks right and I'll generate the PDF report."
-  ]);
+  session.data.summary_confirmation.client_summary_confirmed = true;
+  session.data.summary_confirmation.confirmed_at = new Date().toISOString();
+  session.context.confirmationAwaiting = false;
+  setStage(session, "SEGMENT_G_REPORT");
+  return handleReport(session);
 };
 
-const handlePreviewApproval = (session, text) => {
-  if (!/approve|looks good|confirm/i.test(text)) {
-    return {
-      messages: [
-        "Let me know once you approve the draft so I can create the final report."
-      ]
-    };
-  }
+const enrichAdviceOutcome = (session) => {
+  const profile = session.data.client_profile;
+  const prefs = session.data.sustainability_preferences;
 
+  session.data.advice_outcome.recommendation =
+    session.data.advice_outcome.recommendation ||
+    "Recommendation to be finalised by adviser following compliance review.";
+  session.data.advice_outcome.rationale =
+    session.data.advice_outcome.rationale ||
+    `Client objective ${profile.objectives} with horizon ${profile.horizon_years} years and risk level ${profile.risk_tolerance}/7.`;
+  session.data.advice_outcome.sust_fit =
+    session.data.advice_outcome.sust_fit ||
+    (prefs.preference_level === "none"
+      ? "No explicit sustainability preferences recorded."
+      : `Captured sustainability preferences include ${
+          prefs.labels_interest.join(", ") || "general ESG awareness"
+        }.`);
+  session.data.advice_outcome.costs_summary =
+    session.data.advice_outcome.costs_summary ||
+    "Detailed costs and charges will be attached with product disclosures.";
+};
+
+const handleReport = (session) => {
+  enrichAdviceOutcome(session);
   const validation = validateSessionData(session);
   if (!validation.valid) {
     return {
       messages: [
-        "A validation check failed right before report generation:",
+        "We’re missing some information before I can generate the report:",
         ...validation.issues
       ]
     };
@@ -508,47 +853,49 @@ const handlePreviewApproval = (session, text) => {
 
   const artifacts = generateReportArtifacts(session);
   storeReportArtifacts(session.id, artifacts.pdfBuffer);
+  session.data.audit.report_hash = artifacts.hash;
+  session.data.timestamps.report_generated_at = new Date().toISOString();
+  session.data.report.preview = artifacts.preview;
+  session.data.report.doc_url = `/api/sessions/${session.id}/report.pdf`;
+  session.data.report.status = "draft";
+  session.context.reportReady = true;
 
-  applyDataPatch(session, {
-    report: {
-      status: "draft",
-      doc_url: `/api/sessions/${session.id}/report.pdf`,
-      preview: artifacts.preview,
-      version: session.data.report.version,
-      signed_url: session.data.report.signed_url ?? null
-    }
-  });
-
-  return moveToStage(session, "S6_E_SIGNATURE", [
-    "I've generated your report. You can review it below and download the PDF when you're ready.",
-    "We'll keep the e-signature step static for now, but everything is ready for adviser review."
+  return moveToStage(session, "SEGMENT_H_DELIVERY", [
+    "Great, I’m generating your personalised suitability pack now.",
+    "I’ve prepared your personalised pack. You can download the summary, ESG explainer, and disclosure bundle from the dashboard.",
+    `Report preview:\n${artifacts.preview}`,
+    "If you need anything else, let me know and an adviser will follow up."
   ]);
 };
 
-const handleESignature = () => ({
+const handleDelivery = () => ({
   messages: [
-    "The report is available in your downloads. An adviser will trigger the e-signature request when appropriate."
+    "This session is complete. Your adviser will review everything and attach any product disclosures shortly."
+  ]
+});
+
+const handleComplete = () => ({
+  messages: [
+    "This session is already archived. If you need changes, please start a new one."
   ]
 });
 
 export const handleClientTurn = (session, text) => {
+  const trimmed = text.trim();
   const stageHandlers = {
-    S0_CONSENT: handleConsent,
-    S1_IDENTITY_PROFILE: handleProfile,
-    S2_EDUCATION: handleEducation,
-    S3_PREFERENCE_CAPTURE: handlePreferenceCapture,
-    S4_ADVISER_VALIDATION: handleAdviserValidation,
-    S5_PREVIEW_APPROVAL: handlePreviewApproval,
-    S6_E_SIGNATURE: handleESignature,
-    S7_ARCHIVE: () => ({
-      messages: [
-        "This session is already archived. If you need changes, please start a new one."
-      ]
-    })
+    SEGMENT_A_EXPLANATION: handleExplanation,
+    SEGMENT_B_ONBOARDING: handleOnboarding,
+    SEGMENT_C_CONSENT: handleConsent,
+    SEGMENT_D_EDUCATION: handleEducation,
+    SEGMENT_E_OPTIONS: handleOptions,
+    SEGMENT_F_CONFIRMATION: handleConfirmation,
+    SEGMENT_G_REPORT: handleReport,
+    SEGMENT_H_DELIVERY: handleDelivery,
+    SEGMENT_COMPLETE: handleComplete
   };
 
   const handler = stageHandlers[session.stage] ?? (() => ({ messages: [] }));
-  const response = handler(session, text.trim());
+  const response = handler(session, trimmed);
   saveSession(session);
   return response;
 };

--- a/server/state/sessionStore.js
+++ b/server/state/sessionStore.js
@@ -4,29 +4,78 @@ import { CONVERSATION_STAGES } from "./constants.js";
 
 const sessions = new Map();
 
-const createEmptySessionData = () => ({
-  client: null,
-  acknowledgements: null,
-  preferences: {
-    pathways: [],
-    ethical: {
-      enabled: false,
-      exclusions: []
+const createEmptySessionData = (sessionId) => ({
+  session_id: sessionId,
+  client_profile: {
+    client_type: "",
+    objectives: "",
+    horizon_years: null,
+    risk_tolerance: null,
+    capacity_for_loss: "",
+    liquidity_needs: "",
+    knowledge_experience: {
+      summary: "",
+      instruments: [],
+      frequency: "",
+      duration: ""
     },
-    stewardship: {
-      discretion: "fund_manager"
+    financial_situation: {
+      provided: false,
+      income: null,
+      assets: null,
+      liabilities: null,
+      notes: ""
     }
   },
-  questionnaire_used: false,
-  products: [],
-  adviser_notes: "",
-  fees: {
-    bespoke: false,
-    explanation: ""
+  sustainability_preferences: {
+    preference_level: "none",
+    labels_interest: [],
+    themes: [],
+    exclusions: [],
+    impact_goals: [],
+    engagement_importance: "",
+    reporting_frequency_pref: "none",
+    tradeoff_tolerance: "",
+    educ_pack_sent: false
   },
-  audit: {
-    events: [],
-    ip: null
+  consent: {
+    data_processing: null,
+    e_delivery: null,
+    future_contact: {
+      granted: null,
+      purpose: ""
+    }
+  },
+  summary_confirmation: {
+    client_summary_confirmed: false,
+    confirmed_at: null,
+    edits_requested: ""
+  },
+  advice_outcome: {
+    recommendation: "",
+    rationale: "",
+    sust_fit: "",
+    costs_summary: "",
+    adviser_notes: "",
+    fee_details: {
+      bespoke: false,
+      explanation: ""
+    }
+  },
+  disclosures: {
+    documents: [],
+    agr_disclaimer_presented: false
+  },
+  prod_governance: {
+    target_market_match: null,
+    manufacturer_info_complete: true
+  },
+  timestamps: {
+    explanation_shown_at: null,
+    consent_recorded_at: null,
+    education_completed_at: null,
+    report_generated_at: null,
+    session_closed_at: null
   },
   report: {
     version: "v1.0",
@@ -34,7 +83,14 @@ const createEmptySessionData = () => ({
     signed_url: null,
     status: "draft",
     preview: null
-
+  },
+  audit: {
+    events: [],
+    ip: null,
+    explanation_shown: false,
+    educ_pack_sent: false,
+    guardrail_triggers: [],
+    report_hash: null
   }
 });
 
@@ -47,17 +103,25 @@ export const createSession = ({ ip } = {}) => {
     stage: CONVERSATION_STAGES[0],
     createdAt: timestamp,
     updatedAt: timestamp,
-    data: createEmptySessionData(),
+    data: createEmptySessionData(id),
     events: [],
     context: {
-      profileStep: 0,
-      educationAcknowledged: false,
-      preference: {
-        allocationsCaptured: false,
-        needImpactThemes: false,
-        needEthicalDetail: false,
-        stewardshipAnswered: false
-      }
+      onboardingStep: 0,
+      requireRiskOverride: false,
+      consentStep: 0,
+      education: {
+        acknowledged: false,
+        summaryOffered: false,
+        summarised: false
+      },
+      options: {
+        preferenceLevel: null,
+        step: 0,
+        pendingExclusions: false,
+        pendingImpactDetails: false
+      },
+      confirmationAwaiting: false,
+      reportReady: false
     }
   };
 


### PR DESCRIPTION
## Summary
- refactor the session store, constants, and conversation engine to follow the ESG suitability conversation (segments A–H)
- expand validation and reporting logic to enforce guardrails and render the new suitability report template
- publish supporting specs for the data model, NLU, MI dashboard, and scripted conversation flow

## Testing
- node --input-type=module -e "import('./server/state/conversationEngine.js')"
- node --input-type=module -e "import('./server/state/validateSession.js')"
- node --input-type=module -e "import('./server/report/reportGenerator.js')"
- node --input-type=module -e "import('./server/router.js')"

------
https://chatgpt.com/codex/tasks/task_b_68d65050670083299f63189dafd46fa8