### PR TITLE
Document extended ESG chatbot resources

### DIFF
--- a/educational_pack.md
+++ b/educational_pack.md
@@ -1,0 +1,24 @@
+# ESG & SDR Educational Pack (Bot Text + PDF Reference)
+
+Chatbot micro-modules:
+
+ESG Basics:
+"ESG = Environmental, Social, Governance. A framework for how companies manage sustainability risks & opportunities."
+
+SDR Labels:
+"FCA labels: Focus (strong performers), Improvers (expected to improve), Impact (measurable outcomes), Mixed Goals (combination)."
+
+Anti-Greenwashing:
+"Since May 2024, all sustainability claims must be fair, clear, not misleading, and backed by disclosures."
+
+Trade-offs:
+"Exclusions/themes may limit diversification and affect returns — I’ll flag these so you decide knowingly."
+
+Product Governance:
+"Every fund has a defined target market; recommendations must fit this. Outside-target-market sales are logged and reviewed."
+
+---
+
+Full explainer PDF (for disclosures):
+ESG_SDR_Educational_Pack.pdf — Version 1.0, Sept 2025
+(doc_id: ESG_SDR_Educational_Pack, version: v1.0, hash: sha256-xxx)

--- a/interactive_extension_spec.md
+++ b/interactive_extension_spec.md
@@ -1,0 +1,100 @@
+# Interactive Extension Spec — Personable ESG Suitability Chatbot
+
+This spec extends the structured conversation to support a personable, adaptive, and educational interaction while still ensuring compliant completion of the KBS Pathway template.
+
+---
+
+## 1. Conversation Style & Personality
+- Tone: Warm, professional, approachable; avoids jargon.
+- Use the client’s name when available.
+- Acknowledge responses: “That makes sense,” “Thanks for sharing,” “Appreciate the detail.”
+- Restate goals for confirmation before moving on.
+
+---
+
+## 2. Adaptive Dialogue
+- Allow bounded small talk and acknowledgement of detours.
+- If the user asks “Why do you need that?” → explain compliance rationale (COBS 9A/PROD 3) before resuming.
+- If the user requests more detail (e.g., “Tell me more about Impact investing”) → deliver an educational module, then offer to continue the data capture.
+- Resume prompts: “Would you like to continue where we left off?”
+
+---
+
+## 3. Educational Layer (On-Demand Modules)
+Core modules:
+- ESG basics
+- FCA SDR labels (Focus, Improvers, Impact, Mixed Goals)
+- Anti-Greenwashing Rule
+- Risks & trade-offs
+- Product governance basics
+- Switching considerations
+
+Deep dives (call-outs):
+- Focus vs Improvers — plain-English comparison
+- Exclusions examples — highlight common screens and thresholds
+- Stewardship / engagement — explain active ownership
+
+Format requirements:
+- Deliver a concise summary in chat.
+- Offer the full explainer PDF after each summary: “Would you like the full explainer?”
+- Record which topics were requested for audit.
+
+---
+
+## 4. Extended Data Capture Flow
+- Log all spontaneous educational requests and questions.
+- Add fields to schema:
+```json
+"educational_requests": {"type":"array","items":{"type":"string"}},
+"extra_questions": {"type":"array","items":{"type":"string"}},
+"additional_notes": {"type":"string"}
+```
+- Capture additional_notes for adviser colour commentary and compliance flags.
+
+---
+
+## 5. Dialogue Management Rules
+- Slot-driven but flexible ordering: required compliance fields must eventually be collected.
+- If a slot is skipped because of a detour, schedule a follow-up prompt (“Earlier you skipped liquidity needs. Shall we capture that now?”).
+- Provide progress reminders (“We’re halfway through. Just a few more questions about your ESG preferences.”).
+- Keep transcript chronological, assistant/client alternating.
+
+---
+
+## 6. Validation & Guardrails
+- Parse non-linear inputs: accept multiple fields in one message (“I’m medium risk with an 8 year horizon”).
+- Clarify vague responses (e.g., “I don’t like fossil fuels” → ask whether to exclude all or apply a threshold such as >10% revenue).
+- Maintain existing COBS/PROD guardrails (risk vs horizon, risk vs capacity, label requirements, exclusion thresholds).
+
+---
+
+## 7. Educational Logging & Reporting
+- Log educational detours in `educational_requests[]` with timestamps/context.
+- Log compliance clarifications in `extra_questions[]`.
+- Append narrative context to `additional_notes` for advisers.
+- Ensure the suitability report summarises any educational interactions.
+
+---
+
+## 8. Example Scripted Interactions
+1. **Educational detour**
+   - User: “What is Anti-Greenwashing?”
+   - Bot: “The FCA requires sustainability claims to be fair, clear, and supported by evidence. If I describe a product as sustainable, I’ll show you disclosures. Would you like a one-page summary?”
+   - Log: `educational_requests += ["Anti-Greenwashing"]`
+2. **Exclusions capture**
+   - User: “Avoid coal, tobacco, and weapons.”
+   - Bot: “For coal, should I exclude firms with over 10% revenue? For tobacco and weapons, mark as zero-tolerance?”
+   - Log: `exclusions = [{"sector":"coal","threshold_type":"revenue_%","threshold_value":10},{"sector":"tobacco","threshold_type":"any_exposure"},{"sector":"weapons","threshold_type":"any_exposure"}]`
+3. **Label clarification**
+   - User: “What’s Focus vs Improvers?”
+   - Bot: “Focus funds invest in companies already performing strongly on sustainability. Improvers aim to help companies improve through engagement. Which feels closer to your goals?”
+
+---
+
+## 9. Developer Notes
+- Extend NLU with intents for educational requests and extra compliance questions.
+- Dialogue manager must handle interruptions gracefully and resume until all required slots are filled.
+- Update the JSON schema (`advice_session.schema.json`) with the new arrays/notes.
+- Ensure compliance: all mandatory KBS/COBS/PROD fields must be captured before generating the report.
+- Gating: ESG claims require supporting evidence documents before presentation.
+- Confirm comprehension with periodic summaries and confirmations.

--- a/mi_dashboard_spec.md
+++ b/mi_dashboard_spec.md
@@ -1,0 +1,26 @@
+# MI Dashboard Spec
+
+Datasets:
+- advice_session
+- sales
+- complaints
+- disclosures
+- product_catalogue
+
+KPIs:
+- % complete sessions
+- % outside target market
+- Complaint rates per 1,000
+- AGR guardrail trigger rates
+- Review timeliness
+
+Drilldowns:
+- Target-market heatmap
+- Greenwashing safeguards
+- Exclusions pressure map
+- Vulnerabilities lens
+
+Alerts:
+- Daily: outside-target-market sales > X%
+- Weekly: AGR guardrail activations > threshold
+- Monthly: complaints trend rising

--- a/public/app.js
+++ b/public/app.js
@@ -1,4 +1,5 @@
 const messagesList = document.getElementById("messages");
+const promptText = document.getElementById("current-prompt");
 const stageLabel = document.getElementById("stage");
 const sessionIdLabel = document.getElementById("session-id");
 const sessionDataBlock = document.getElementById("session-data");
@@ -10,6 +11,12 @@ const reportSection = document.getElementById("report-section");
 const reportPreview = document.getElementById("report-preview");
 const reportDownload = document.getElementById("report-download");
 const stageFormContainer = document.getElementById("stage-form");
+const educationPackToggle = document.getElementById("view-education-pack");
+const educationPackSection = document.getElementById("education-pack");
+const educationPackClose = document.getElementById("close-education-pack");
+const educationPackReturn = document.getElementById("return-to-questionnaire");
+
+const bodyElement = document.body;
 
 const CLIENT_TYPES = ["individual", "joint", "trust", "company"];
 const RISK_SCALE = [1, 2, 3, 4, 5, 6, 7];
@@ -32,6 +39,12 @@ const REPORTING_FREQUENCY_OPTIONS = [
   "annual"
 ];
 
+const setActivePrompt = (text) => {
+  if (!promptText) return;
+  const trimmed = String(text ?? "").trim();
+  promptText.textContent = trimmed || "Waiting for the assistant…";
+};
+
 const addMessage = (author, text) => {
   const item = document.createElement("li");
   item.dataset.author = author;
@@ -45,18 +58,20 @@ const addMessage = (author, text) => {
   item.appendChild(label);
   item.appendChild(body);
 
-  if (messagesList.firstChild) {
-    messagesList.insertBefore(item, messagesList.firstChild);
-  } else {
-    messagesList.appendChild(item);
-  }
+  messagesList.appendChild(item);
 
   if (typeof messagesList.scrollTo === "function") {
-    messagesList.scrollTo({ top: 0, behavior: "smooth" });
+    messagesList.scrollTo({
+      top: messagesList.scrollHeight,
+      behavior: "smooth"
+    });
   } else {
-    messagesList.scrollTop = 0;
+    messagesList.scrollTop = messagesList.scrollHeight;
   }
-  item.scrollIntoView({ behavior: "smooth", block: "nearest" });
+
+  if (author === "assistant") {
+    setActivePrompt(text);
+  }
 };
 
 const setStage = (stage) => {
@@ -105,6 +120,80 @@ const api = async (path, options = {}) => {
 
 let currentSessionId = null;
 let currentSession = null;
+let educationPackAutoOpened = false;
+
+const openEducationPack = () => {
+  if (!educationPackSection) return;
+  educationPackSection.hidden = false;
+  if (bodyElement) {
+    bodyElement.classList.add("education-pack-open");
+  }
+  if (educationPackToggle) {
+    educationPackToggle.setAttribute("aria-expanded", "true");
+  }
+  const focusTarget = educationPackSection.querySelector(".education-pack__close") ?? educationPackSection;
+  focusTarget.focus();
+};
+
+const closeEducationPack = () => {
+  if (!educationPackSection) return;
+  const wasOpen = educationPackSection.hidden === false;
+  educationPackSection.hidden = true;
+  if (bodyElement) {
+    bodyElement.classList.remove("education-pack-open");
+  }
+  if (wasOpen && educationPackToggle) {
+    educationPackToggle.setAttribute("aria-expanded", "false");
+    if (!educationPackToggle.hidden) {
+      educationPackToggle.focus();
+    } else if (messageInput) {
+      messageInput.focus();
+    }
+  } else if (wasOpen && messageInput) {
+    messageInput.focus();
+  }
+};
+
+const updateEducationPackAvailability = (session) => {
+  const delivered =
+    session?.stage === "SEGMENT_D_EDUCATION" ||
+    session?.data?.sustainability_preferences?.educ_pack_sent === true;
+
+  if (educationPackToggle) {
+    educationPackToggle.hidden = !delivered;
+    if (delivered) {
+      const label =
+        session?.stage === "SEGMENT_D_EDUCATION"
+          ? "Open ESG education pack"
+          : "Review ESG education pack";
+      educationPackToggle.textContent = label;
+    } else {
+      educationPackToggle.setAttribute("aria-expanded", "false");
+    }
+  }
+
+  if (!delivered) {
+    educationPackAutoOpened = false;
+    closeEducationPack();
+    return;
+  }
+
+  if (session?.stage === "SEGMENT_D_EDUCATION" && !educationPackAutoOpened) {
+    openEducationPack();
+    educationPackAutoOpened = true;
+  }
+};
+
+educationPackToggle?.addEventListener("click", openEducationPack);
+educationPackClose?.addEventListener("click", closeEducationPack);
+educationPackReturn?.addEventListener("click", closeEducationPack);
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && bodyElement?.classList.contains("education-pack-open")) {
+    event.preventDefault();
+    closeEducationPack();
+  }
+});
 
 const parseNumberField = (value) => {
   const trimmed = String(value ?? "").trim();
@@ -886,6 +975,7 @@ const setSessionData = (session) => {
   setStage(session.stage);
   updateReport(session);
   renderStageForm(session);
+  updateEducationPackAvailability(session);
 };
 
 const bootstrap = async () => {

--- a/public/index.html
+++ b/public/index.html
@@ -28,22 +28,41 @@
         </span>
       </section>
 
-      <section class="chat" aria-label="Chat transcript">
-        <ul id="messages" class="chat__messages"></ul>
+      <button
+        type="button"
+        id="view-education-pack"
+        class="education-pack-toggle"
+        aria-controls="education-pack"
+        aria-expanded="false"
+        hidden
+      >
+        View ESG education pack
+      </button>
+
+      <section class="interaction" aria-live="polite" aria-label="Assistant prompt">
+        <div class="interaction__prompt">
+          <h2>Assistant question</h2>
+          <p id="current-prompt" class="interaction__prompt-text">
+            Loading the first prompt…
+          </p>
+        </div>
         <form id="composer" class="composer" autocomplete="off">
-          <label class="composer__label" for="message-input">
-            Respond to continue the onboarding conversation
-          </label>
+          <label class="composer__label" for="message-input">Your response</label>
           <textarea
             id="message-input"
             name="message"
             required
-            placeholder="Type your response"
+            placeholder="Share your reply"
             rows="3"
           ></textarea>
           <button type="submit" id="send-button">Send</button>
           <p id="error" role="alert" class="composer__error" hidden></p>
         </form>
+      </section>
+
+      <section class="chat" aria-label="Conversation transcript">
+        <h2 class="chat__title">Conversation transcript</h2>
+        <ul id="messages" class="chat__messages"></ul>
       </section>
 
       <section
@@ -74,6 +93,116 @@
         <a id="report-download" href="#" download="preference-pathway.pdf">
           Download PDF report
         </a>
+      </section>
+
+      <section
+        id="education-pack"
+        class="education-pack"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="education-pack-title"
+        tabindex="-1"
+        hidden
+      >
+        <div class="education-pack__header">
+          <h2 id="education-pack-title">ESG education pack</h2>
+          <button type="button" id="close-education-pack" class="education-pack__close">
+            Return to questionnaire
+          </button>
+        </div>
+        <div class="education-pack__intro">
+          <p>
+            This pack summarises the key sustainability disclosures required by the
+            FCA’s Sustainability Disclosure Requirements (SDR) and Consumer Duty.
+            Review the highlights below and let us know when you’re ready to
+            continue.
+          </p>
+        </div>
+        <div class="education-pack__content">
+          <section>
+            <h3>1. ESG essentials</h3>
+            <ul>
+              <li>ESG stands for Environmental, Social and Governance factors.</li>
+              <li>
+                These factors highlight sustainability characteristics but do not
+                guarantee positive outcomes or investment performance.
+              </li>
+              <li>
+                We assess ESG data alongside financial suitability to make
+                balanced recommendations.
+              </li>
+            </ul>
+          </section>
+          <section>
+            <h3>2. FCA SDR labels</h3>
+            <p>The four labels help you understand a fund’s sustainability focus:</p>
+            <ul>
+              <li><strong>Focus</strong>: invests mainly in companies already leading on sustainability.</li>
+              <li><strong>Improvers</strong>: supports companies working to raise their sustainability performance.</li>
+              <li><strong>Impact</strong>: targets investments delivering measurable real-world outcomes.</li>
+              <li><strong>Mixed Goals</strong>: blends sustainability aims with traditional financial goals.</li>
+            </ul>
+          </section>
+          <section>
+            <h3>3. Anti-Greenwashing safeguards</h3>
+            <ul>
+              <li>
+                We only describe a product as sustainable when evidence supports the
+                claim.
+              </li>
+              <li>
+                Disclosures and fact sheets are provided with every recommendation
+                for you to review.
+              </li>
+              <li>
+                You can request more detail or supporting documents at any time.
+              </li>
+            </ul>
+          </section>
+          <section>
+            <h3>4. Risks, trade-offs, and governance</h3>
+            <ul>
+              <li>
+                Sustainable investments can still rise or fall in value and may
+                underperform broader markets over certain periods.
+              </li>
+              <li>
+                Product governance rules require us to match you with suitable
+                solutions based on your goals, timeline, and risk appetite.
+              </li>
+              <li>
+                Stewardship expectations guide how managers engage with companies
+                to drive improvements.
+              </li>
+            </ul>
+          </section>
+          <section>
+            <h3>5. Switching considerations</h3>
+            <ul>
+              <li>
+                Moving from an existing product could trigger costs, exit charges,
+                or capital gains.
+              </li>
+              <li>
+                We factor these impacts into suitability assessments before
+                recommending any changes.
+              </li>
+              <li>
+                Let us know if you have any restrictions or timelines we should
+                consider before switching.
+              </li>
+            </ul>
+          </section>
+        </div>
+        <footer class="education-pack__footer">
+          <p>
+            Need the full explainer or disclosures? Ask the assistant and we’ll
+            attach the detailed PDF pack for download.
+          </p>
+          <button type="button" class="education-pack__close" id="return-to-questionnaire">
+            Close and continue
+          </button>
+        </footer>
       </section>
     </main>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -11,6 +11,32 @@ body {
   min-height: 100vh;
 }
 
+.education-pack-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  background: rgba(30, 41, 59, 0.75);
+  color: #f8fafc;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 120ms ease, transform 120ms ease;
+}
+
+.education-pack-toggle:hover,
+.education-pack-toggle:focus-visible {
+  background: rgba(59, 130, 246, 0.75);
+}
+
+.education-pack-toggle:focus-visible {
+  outline: 2px solid rgba(148, 197, 255, 0.9);
+  outline-offset: 2px;
+}
+
 .app {
   display: grid;
   grid-template-columns: 2fr 1fr;
@@ -66,6 +92,34 @@ body {
   color: inherit;
 }
 
+.interaction {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.interaction__prompt {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.interaction__prompt h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #38bdf8;
+}
+
+.interaction__prompt-text {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
 .chat {
   background: rgba(15, 23, 42, 0.6);
   border: 1px solid rgba(148, 163, 184, 0.3);
@@ -76,6 +130,14 @@ body {
   gap: 1rem;
 }
 
+.chat__title {
+  margin: 0;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #38bdf8;
+}
+
 .chat__messages {
   list-style: none;
   margin: 0;
@@ -83,7 +145,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  max-height: 55vh;
+  max-height: 45vh;
   overflow-y: auto;
 }
 
@@ -334,6 +396,110 @@ body {
   box-shadow: 0 10px 20px rgba(56, 189, 248, 0.35);
 }
 
+.education-pack {
+  position: fixed;
+  inset: 2rem;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 1.25rem;
+  box-shadow: 0 24px 64px rgba(8, 15, 32, 0.6);
+  color: #f8fafc;
+  overflow-y: auto;
+}
+
+.education-pack[hidden] {
+  display: none !important;
+}
+
+.education-pack__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.education-pack__intro {
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.education-pack__content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.education-pack__content section {
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1rem;
+  padding: 1.25rem;
+}
+
+.education-pack__content section h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+  color: #38bdf8;
+}
+
+.education-pack__content ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  line-height: 1.6;
+}
+
+.education-pack__footer {
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+  padding-top: 1rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.education-pack__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.75rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: #38bdf8;
+  color: #0f172a;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 120ms ease, transform 120ms ease;
+}
+
+.education-pack__close:hover,
+.education-pack__close:focus-visible {
+  background: #0ea5e9;
+}
+
+.education-pack__close:focus-visible {
+  outline: 2px solid rgba(148, 197, 255, 0.9);
+  outline-offset: 2px;
+}
+
+body.education-pack-open {
+  overflow: hidden;
+}
+
+body.education-pack-open .interaction,
+body.education-pack-open .chat,
+body.education-pack-open .structured,
+body.education-pack-open .summary,
+body.education-pack-open .report {
+  display: none;
+}
+
+body.education-pack-open .education-pack-toggle {
+  display: none;
+}
+
 @media (max-width: 900px) {
   .app {
     grid-template-columns: 1fr;
@@ -342,5 +508,12 @@ body {
   .status {
     flex-direction: column;
     align-items: flex-start;
+  }
+}
+
+@media (max-width: 768px) {
+  .education-pack {
+    inset: 0;
+    border-radius: 0;
   }
 }

--- a/server/spec/advice_session.schema.json
+++ b/server/spec/advice_session.schema.json
@@ -12,6 +12,15 @@
     "disclosures": {"type": "object"},
     "prod_governance": {"type": "object"},
     "timestamps": {"type": "object"},
-    "audit": {"type": "object"}
+    "audit": {"type": "object"},
+    "educational_requests": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "extra_questions": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "additional_notes": {"type": "string"}
   }
 }

--- a/server/spec/conversation_flow.md
+++ b/server/spec/conversation_flow.md
@@ -80,6 +80,15 @@ Outputs:
 
 ---
 
+## Adaptive Dialogue Enhancements
+- Warm tone with acknowledgements ("Thanks for sharing...", "That makes sense.") and confirmation prompts restating the client's goals and horizon.
+- Educational detours: when the client asks for explainers (e.g. "Tell me more about Impact investing"), the assistant delivers a short summary, offers a PDF, logs the topic in `educational_requests[]`, then asks, "Would you like to continue where we left off?"
+- Compliance clarifications: if the client asks "Why do you need that?", the assistant explains the relevant COBS 9A/PROD requirement, logs the query in `extra_questions[]`, and re-asks the pending suitability question.
+- Progress reminder midway through ("We're halfway through. Just a few more questions about your ESG preferences.").
+- Additional audit notes recorded in `additional_notes` for adviser context.
+
+---
+
 # Compliance Guardrails
 - Consumer Duty: plain language + comprehension checks.
 - COBS 9A: suitability fields complete before recommendation.

--- a/server/spec/nlu_spec.yaml
+++ b/server/spec/nlu_spec.yaml
@@ -5,6 +5,10 @@ intents:
     examples: ["Medium risk", "Risk 5 out of 7"]
   - name: capture_exclusions
     examples: ["Exclude coal", "No tobacco"]
+  - name: educational_request
+    examples: ["Tell me more about Impact", "What is Anti-Greenwashing?"]
+  - name: extra_question
+    examples: ["Why do you need that?", "What’s this for?"]
 
 entities:
   - risk_level
@@ -19,3 +23,4 @@ validation_rules:
   - rule: Require risk & horizon before recommendation
   - rule: Require thresholds for exclusions
   - rule: If Impact label chosen, require impact_goals
+  - rule: All required suitability fields must be captured before final report

--- a/server/state/sessionStore.js
+++ b/server/state/sessionStore.js
@@ -94,7 +94,10 @@ const createEmptySessionData = (sessionId) => ({
     educ_pack_sent: false,
     guardrail_triggers: [],
     report_hash: null
-  }
+  },
+  educational_requests: [],
+  extra_questions: [],
+  additional_notes: ""
 });
 
 export const createSession = ({ ip } = {}) => {


### PR DESCRIPTION
## Summary
- expand the personable chatbot extension spec with dialogue management, guardrails, and scripted interactions
- add dedicated educational pack and MI dashboard specification documents for reference
- update the NLU spec examples and validation rules to cover educational requests and mandatory suitability data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d6c4ee20688329ac06ae38b8b3252c