### PR TITLE
Ensure OpenAI stub registers before conversation module

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "scripts": {
     "start": "node server/server.js",
     "test": "node --test"
+  },
+  "dependencies": {
+    "openai": "^4.52.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,12 @@
             placeholder="Share your reply"
             rows="3"
           ></textarea>
-          <button type="submit" id="send-button">Send</button>
+          <div class="composer__actions">
+            <button type="submit" id="send-button">Send</button>
+            <button type="button" id="ask-button" class="composer__ask">
+              Ask a question
+            </button>
+          </div>
           <p id="error" role="alert" class="composer__error" hidden></p>
         </form>
       </section>

--- a/public/styles.css
+++ b/public/styles.css
@@ -221,6 +221,18 @@ body {
   box-shadow: 0 10px 20px rgba(14, 165, 233, 0.4);
 }
 
+.composer__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.composer__actions > button {
+  flex: 1 1 auto;
+  min-width: 8rem;
+}
+
 .composer__error {
   margin: 0;
   color: #f87171;

--- a/server/integrations/openAiClient.js
+++ b/server/integrations/openAiClient.js
@@ -1,0 +1,122 @@
+const DEFAULT_MODEL = process.env.OPENAI_MODEL ?? "gpt-4o-mini";
+
+export const COMPLIANCE_SYSTEM_PROMPT = `You are an FCA Consumer Duty compliance co-pilot.
+- Answer as the assistant for a UK sustainability preference pathway meeting.
+- Be transparent about guardrails and note when adviser review is required.
+- Keep the client on topic with SDR, ESG, and suitability requirements.
+- Always return valid JSON matching the provided schema.`;
+
+const complianceSchema = {
+  name: "compliance_response",
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["reply"],
+    properties: {
+      reply: {
+        type: "string",
+        description:
+          "Natural language response to the client's free-form query."
+      },
+      compliance: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          educational_requests: {
+            type: "array",
+            items: { type: "string" }
+          },
+          extra_questions: {
+            type: "array",
+            items: { type: "string" }
+          },
+          notes: {
+            type: "array",
+            items: { type: "string" }
+          }
+        }
+      }
+    }
+  }
+};
+
+let cachedClient = null;
+let OpenAIClass = null;
+let responder = null;
+
+const loadOpenAI = async () => {
+  if (OpenAIClass) {
+    return OpenAIClass;
+  }
+
+  try {
+    const mod = await import("openai");
+    OpenAIClass = mod?.default ?? mod.OpenAI ?? mod;
+    return OpenAIClass;
+  } catch (error) {
+    throw Object.assign(new Error("The openai package is not installed"), {
+      status: 500
+    });
+  }
+};
+
+const getClient = async () => {
+  if (cachedClient) {
+    return cachedClient;
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw Object.assign(new Error("OPENAI_API_KEY is not configured"), {
+      status: 500
+    });
+  }
+
+  const OpenAIConstructor = await loadOpenAI();
+  cachedClient = new OpenAIConstructor({ apiKey });
+  return cachedClient;
+};
+
+const parseContent = (choice) => {
+  const content = choice?.message?.content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => (typeof part?.text === "string" ? part.text : ""))
+      .join("");
+  }
+  return "";
+};
+
+const defaultResponder = async ({ messages, model = DEFAULT_MODEL }) => {
+  const client = await getClient();
+  const completion = await client.chat.completions.create({
+    model,
+    messages,
+    response_format: { type: "json_schema", json_schema: complianceSchema },
+    temperature: 0.2
+  });
+
+  const content = parseContent(completion.choices?.[0]);
+  if (!content) {
+    throw new Error("OpenAI returned an empty response");
+  }
+
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    throw new Error("OpenAI returned invalid JSON payload");
+  }
+};
+
+export const setComplianceResponder = (fn) => {
+  responder = typeof fn === "function" ? fn : null;
+};
+
+export const callComplianceResponder = async (payload) => {
+  const handler = responder ?? defaultResponder;
+  return handler(payload);
+};
+

--- a/server/state/conversationEngine.js
+++ b/server/state/conversationEngine.js
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   CAPACITY_FOR_LOSS_VALUES,
   CLIENT_TYPES,
@@ -9,6 +10,7 @@ import {
   STAGE_PROMPTS
 } from "./constants.js";
 import {
+  appendEvent,
   applyDataPatch,
   saveSession,
   setStage
@@ -16,6 +18,10 @@ import {
 import { validateSessionData } from "./validateSession.js";
 import { generateReportArtifacts } from "../report/reportGenerator.js";
 import { storeReportArtifacts } from "../report/reportStore.js";
+import {
+  callComplianceResponder,
+  COMPLIANCE_SYSTEM_PROMPT
+} from "../integrations/openAiClient.js";
 
 const yesPatterns = /\b(yes|yep|i (consent|agree|understand|accept)|sure|ok(ay)?|ready)\b/i;
 const noPatterns = /\b(no|nope|not (yet|now)|decline|refuse)\b/i;
@@ -192,6 +198,168 @@ const appendAdditionalNote = (session, note) => {
   if (!note) return;
   const existing = session.data.additional_notes ?? "";
   session.data.additional_notes = existing ? `${existing}\n${note}` : note;
+};
+
+const captureProgressSnapshot = (session) => {
+  const education = session.context.education ?? {};
+  const options = session.context.options ?? {};
+  return {
+    stage: session.stage,
+    onboardingStep:
+      session.context.onboardingStep ?? null,
+    consentStep: session.context.consentStep ?? null,
+    education: {
+      acknowledged: Boolean(education.acknowledged),
+      summaryOffered: Boolean(education.summaryOffered),
+      summarised: Boolean(education.summarised)
+    },
+    options: {
+      preferenceLevel: options.preferenceLevel ?? null,
+      step: options.step ?? null
+    },
+    confirmationAwaiting: Boolean(session.context.confirmationAwaiting),
+    reportReady: Boolean(session.context.reportReady)
+  };
+};
+
+const hasProgressed = (before, after) => {
+  if (!before) return true;
+  if (before.stage !== after.stage) return true;
+  if (before.onboardingStep !== after.onboardingStep) return true;
+  if (before.consentStep !== after.consentStep) return true;
+  if (before.confirmationAwaiting !== after.confirmationAwaiting) return true;
+  if (before.reportReady !== after.reportReady) return true;
+  if (
+    before.education.acknowledged !== after.education.acknowledged ||
+    before.education.summaryOffered !== after.education.summaryOffered ||
+    before.education.summarised !== after.education.summarised
+  ) {
+    return true;
+  }
+  if (
+    before.options.preferenceLevel !== after.options.preferenceLevel ||
+    before.options.step !== after.options.step
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const summariseSessionForLLM = (session) => {
+  const profile = session.data?.client_profile ?? {};
+  const prefs = session.data?.sustainability_preferences ?? {};
+  const consent = session.data?.consent ?? {};
+  const summaryLines = [
+    `Current stage: ${session.stage}`,
+    `Client type: ${profile.client_type || "unspecified"}`,
+    `Objective: ${profile.objectives || "unspecified"}`,
+    `Horizon: ${profile.horizon_years ?? "—"} years`,
+    `Risk tolerance: ${profile.risk_tolerance ?? "—"}`,
+    `Capacity for loss: ${profile.capacity_for_loss || "unspecified"}`,
+    `Liquidity needs: ${profile.liquidity_needs || "unspecified"}`,
+    `Knowledge summary: ${profile.knowledge_experience?.summary || "—"}`,
+    `Financial context provided: ${profile.financial_situation?.provided ? "yes" : "no"}`,
+    `Preference level: ${prefs.preference_level || "none"}`,
+    `Label interests: ${(prefs.labels_interest ?? []).join(", ") || "None"}`,
+    `Impact goals: ${(prefs.impact_goals ?? []).join(", ") || "None"}`,
+    `Reporting preference: ${prefs.reporting_frequency_pref || "none"}`,
+    `Consent to data processing: ${
+      consent?.data_processing?.granted === true ? "granted" : "pending"
+    }`
+  ];
+  return `Session summary:\n${summaryLines.join("\n")}`;
+};
+
+const mapEventToChatMessage = (event) => {
+  if (!event) return null;
+  if (event.type === "message" && typeof event.content?.text === "string") {
+    if (event.author === "client") {
+      return { role: "user", content: event.content.text };
+    }
+    if (event.author === "assistant") {
+      return { role: "assistant", content: event.content.text };
+    }
+  }
+  if (event.author === "client" && event.type === "data_update") {
+    const payload = JSON.stringify(event.content ?? {});
+    return {
+      role: "user",
+      content: `Client submitted structured data: ${payload}`
+    };
+  }
+  return null;
+};
+
+const buildChatHistory = (session) =>
+  ensureArray(session.events)
+    .map((event) => mapEventToChatMessage(event))
+    .filter(Boolean);
+
+const persistComplianceData = (session, compliance = {}) => {
+  if (!compliance || typeof compliance !== "object") return;
+
+  ensureStringArray(compliance.educational_requests).forEach((entry) => {
+    appendSessionArrayEntry(session, "educational_requests", entry);
+  });
+  ensureStringArray(compliance.extra_questions).forEach((entry) => {
+    appendSessionArrayEntry(session, "extra_questions", entry);
+  });
+  ensureStringArray(compliance.notes).forEach((note) => {
+    appendAdditionalNote(session, note);
+  });
+};
+
+export const handleFreeFormQuery = async (
+  session,
+  text,
+  additionalMessages = []
+) => {
+  const trimmed = String(text ?? "").trim();
+  if (!trimmed) {
+    return {
+      messages: Array.isArray(additionalMessages) ? additionalMessages : []
+    };
+  }
+
+  const history = buildChatHistory(session);
+  const messages = [
+    {
+      role: "system",
+      content: `${COMPLIANCE_SYSTEM_PROMPT}\n\n${summariseSessionForLLM(session)}`
+    },
+    ...history,
+    { role: "user", content: trimmed }
+  ];
+
+  const aiPayload = await callComplianceResponder({ messages });
+  if (!aiPayload || typeof aiPayload.reply !== "string") {
+    throw new Error("Compliance assistant returned an unexpected payload");
+  }
+
+  const compliance = aiPayload.compliance ?? {};
+  persistComplianceData(session, compliance);
+
+  appendEvent(session, {
+    id: randomUUID(),
+    sessionId: session.id,
+    author: "assistant",
+    type: "message",
+    content: {
+      text: aiPayload.reply,
+      source: "openai",
+      compliance
+    },
+    createdAt: new Date().toISOString()
+  });
+
+  const tail = Array.isArray(additionalMessages)
+    ? additionalMessages.filter((item) => typeof item === "string" && item.trim())
+    : [];
+
+  return {
+    messages: [aiPayload.reply, ...tail],
+    compliance
+  };
 };
 
 const removeTrailingQuestionMark = (question = "") => {
@@ -1642,8 +1810,8 @@ const handleComplete = () => ({
   ]
 });
 
-export const handleClientTurn = (session, text) => {
-  const trimmed = text.trim();
+export const handleClientTurn = async (session, text) => {
+  const trimmed = String(text ?? "").trim();
   const detour = handleDetours(session, trimmed);
   if (detour) {
     saveSession(session);
@@ -1663,9 +1831,37 @@ export const handleClientTurn = (session, text) => {
   };
 
   const handler = stageHandlers[session.stage] ?? (() => ({ messages: [] }));
+  const before = captureProgressSnapshot(session);
   const response = handler(session, trimmed);
+  const after = captureProgressSnapshot(session);
+
+  const progressed = hasProgressed(before, after);
+  if (progressed || !trimmed) {
+    saveSession(session);
+    return response;
+  }
+
+  let finalResponse;
+  try {
+    finalResponse = await handleFreeFormQuery(
+      session,
+      trimmed,
+      response?.messages ?? []
+    );
+  } catch (error) {
+    const fallback = Array.isArray(response?.messages)
+      ? response.messages
+      : [];
+    finalResponse = {
+      messages: [
+        ...fallback,
+        "I’m unable to escalate this question to the compliance assistant right now. Please try again later or clarify your response."
+      ]
+    };
+  }
+
   saveSession(session);
-  return response;
+  return finalResponse;
 };
 
 export const handleAssistantMessage = (session, content) => {
@@ -1674,7 +1870,7 @@ export const handleAssistantMessage = (session, content) => {
   return { messages: [] };
 };
 
-export const handleEvent = (session, event) => {
+export const handleEvent = async (session, event) => {
   if (event.author === "client" && event.type === "message") {
     return handleClientTurn(session, event.content?.text ?? "");
   }

--- a/tests/conversationEngine.test.js
+++ b/tests/conversationEngine.test.js
@@ -4,6 +4,14 @@ import assert from "node:assert";
 process.env.SESSION_DB_PATH = ":memory:";
 
 const sessionStore = await import("../server/state/sessionStore.js");
+const openAi = await import("../server/integrations/openAiClient.js");
+
+const unexpectedOpenAiCall = async () => {
+  throw new Error("OpenAI stub was not configured for this test");
+};
+
+openAi.setComplianceResponder(unexpectedOpenAiCall);
+
 const conversation = await import("../server/state/conversationEngine.js");
 
 const createEvent = (stage, content) => ({
@@ -14,13 +22,13 @@ const createEvent = (stage, content) => ({
   content
 });
 
-test("structured onboarding persists suitability answers and advances to consent", () => {
+test("structured onboarding persists suitability answers and advances to consent", async () => {
   sessionStore.resetSessions();
   const session = sessionStore.createSession();
 
-  conversation.handleEvent(session, createEvent(session.stage, { ready: true }));
+  await conversation.handleEvent(session, createEvent(session.stage, { ready: true }));
 
-  const result = conversation.handleEvent(
+  const result = await conversation.handleEvent(
     session,
     createEvent(session.stage, {
       answers: {
@@ -63,11 +71,11 @@ test("structured onboarding persists suitability answers and advances to consent
   );
 });
 
-test("structured consent flow records timestamps and advances to education", () => {
+test("structured consent flow records timestamps and advances to education", async () => {
   sessionStore.resetSessions();
   const session = sessionStore.createSession();
-  conversation.handleEvent(session, createEvent(session.stage, { ready: true }));
-  conversation.handleEvent(
+  await conversation.handleEvent(session, createEvent(session.stage, { ready: true }));
+  await conversation.handleEvent(
     session,
     createEvent(session.stage, {
       answers: {
@@ -84,7 +92,7 @@ test("structured consent flow records timestamps and advances to education", () 
   );
 
   const before = Date.now();
-  conversation.handleEvent(
+  await conversation.handleEvent(
     session,
     createEvent(session.stage, {
       consent: {
@@ -101,11 +109,11 @@ test("structured consent flow records timestamps and advances to education", () 
   assert.ok(Date.parse(session.data.timestamps.consent_recorded_at) >= before);
 });
 
-test("structured options require impact goals when Impact label is chosen", () => {
+test("structured options require impact goals when Impact label is chosen", async () => {
   sessionStore.resetSessions();
   const session = sessionStore.createSession();
-  conversation.handleEvent(session, createEvent(session.stage, { ready: true }));
-  conversation.handleEvent(
+  await conversation.handleEvent(session, createEvent(session.stage, { ready: true }));
+  await conversation.handleEvent(
     session,
     createEvent(session.stage, {
       answers: {
@@ -120,7 +128,7 @@ test("structured options require impact goals when Impact label is chosen", () =
       }
     })
   );
-  conversation.handleEvent(
+  await conversation.handleEvent(
     session,
     createEvent(session.stage, {
       consent: {
@@ -130,9 +138,9 @@ test("structured options require impact goals when Impact label is chosen", () =
       }
     })
   );
-  conversation.handleEvent(session, createEvent(session.stage, { acknowledged: true }));
+  await conversation.handleEvent(session, createEvent(session.stage, { acknowledged: true }));
 
-  const result = conversation.handleEvent(
+  const result = await conversation.handleEvent(
     session,
     createEvent(session.stage, {
       preferences: {
@@ -156,14 +164,14 @@ test("structured options require impact goals when Impact label is chosen", () =
   );
 });
 
-test("onboarding handles multi-field answers and confirms goals", () => {
+test("onboarding handles multi-field answers and confirms goals", async () => {
   sessionStore.resetSessions();
   const session = sessionStore.createSession();
   session.stage = "SEGMENT_B_ONBOARDING";
   session.context.onboardingStep = 2;
   session.data.client_profile.objectives = "growth";
 
-  const response = conversation.handleClientTurn(
+  const response = await conversation.handleClientTurn(
     session,
     "Around 8 years and I'm medium risk"
   );
@@ -181,13 +189,13 @@ test("onboarding handles multi-field answers and confirms goals", () => {
   );
 });
 
-test("educational detours log requests and offer to resume", () => {
+test("educational detours log requests and offer to resume", async () => {
   sessionStore.resetSessions();
   const session = sessionStore.createSession();
   session.stage = "SEGMENT_B_ONBOARDING";
   session.context.onboardingStep = 2;
 
-  const response = conversation.handleClientTurn(
+  const response = await conversation.handleClientTurn(
     session,
     "Tell me more about Impact investing"
   );
@@ -207,13 +215,13 @@ test("educational detours log requests and offer to resume", () => {
   );
 });
 
-test("compliance clarifications log extra questions", () => {
+test("compliance clarifications log extra questions", async () => {
   sessionStore.resetSessions();
   const session = sessionStore.createSession();
   session.stage = "SEGMENT_B_ONBOARDING";
   session.context.onboardingStep = 2;
 
-  const response = conversation.handleClientTurn(
+  const response = await conversation.handleClientTurn(
     session,
     "Why do you need that?"
   );
@@ -227,4 +235,55 @@ test("compliance clarifications log extra questions", () => {
     session.data.extra_questions.some((entry) => /Why do you need that/i.test(entry)),
     "should capture the clarification in extra_questions"
   );
+});
+
+test("free-form fallback routes questions to the compliance assistant", async () => {
+  sessionStore.resetSessions();
+  const session = sessionStore.createSession();
+  session.stage = "SEGMENT_B_ONBOARDING";
+  session.context.onboardingStep = 0;
+
+  const stub = async () => ({
+    reply: "Here’s what to consider about fees and ESG reporting.",
+    compliance: {
+      educational_requests: ["Free-form question: fees and ESG reporting"],
+      notes: ["Logged compliance assistant free-form response."]
+    }
+  });
+
+  openAi.setComplianceResponder(stub);
+
+  try {
+    const result = await conversation.handleClientTurn(
+      session,
+      "I just want to check fees and reporting."
+    );
+
+    assert.ok(
+      result.messages[0].includes("fees and ESG reporting"),
+      "should return the OpenAI reply first"
+    );
+    assert.ok(
+      result.messages.some((message) => /individual, joint, trust, or company/i.test(message)),
+      "should retain the stage guidance after the assistant reply"
+    );
+
+    const lastEvent = session.events.at(-1);
+    assert.strictEqual(lastEvent.author, "assistant");
+    assert.strictEqual(lastEvent.content?.source, "openai");
+    assert.ok(lastEvent.content?.text.includes("fees and ESG reporting"));
+
+    assert.ok(
+      session.data.educational_requests.some((entry) =>
+        entry.includes("fees and ESG reporting")
+      )
+    );
+    assert.ok(
+      (session.data.additional_notes || "").includes(
+        "Logged compliance assistant free-form response."
+      )
+    );
+  } finally {
+    openAi.setComplianceResponder(unexpectedOpenAiCall);
+  }
 });


### PR DESCRIPTION
## Summary
- import the OpenAI client and register the test stub before loading the conversation engine module
- guarantee the conversation engine sees the stubbed responder during module initialisation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dce5d157e88329b2af2c329263c4ce