### PR TITLE
Refine unauthorized fallback export

### DIFF
--- a/scripts/git-maintenance.sh
+++ b/scripts/git-maintenance.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTE="${1:-origin}"
+MAIN_BRANCH="${2:-main}"
+
+check_remote() {
+  if git remote get-url "$REMOTE" >/dev/null 2>&1; then
+    echo "Remote '$REMOTE' detected. Fetching $MAIN_BRANCH..."
+    if git fetch "$REMOTE" "$MAIN_BRANCH" >/dev/null 2>&1; then
+      local_ref=$(git rev-parse "$MAIN_BRANCH" 2>/dev/null || echo "")
+      remote_ref=$(git rev-parse "$REMOTE/$MAIN_BRANCH" 2>/dev/null || echo "")
+      if [[ -n "$local_ref" && -n "$remote_ref" ]]; then
+        if [[ "$local_ref" == "$remote_ref" ]]; then
+          echo "Local $MAIN_BRANCH matches $REMOTE/$MAIN_BRANCH."
+        else
+          echo "Local $MAIN_BRANCH differs from $REMOTE/$MAIN_BRANCH." >&2
+          git --no-pager log --oneline "${MAIN_BRANCH}..${REMOTE}/${MAIN_BRANCH}" || true
+        fi
+      else
+        echo "Unable to resolve one of the refs for $MAIN_BRANCH." >&2
+      fi
+    else
+      echo "Fetch failed for $REMOTE/$MAIN_BRANCH." >&2
+    fi
+  else
+    echo "Remote '$REMOTE' is not configured; skipping fetch."
+  fi
+}
+
+cleanup_benches() {
+  if ! git rev-parse --verify "$MAIN_BRANCH" >/dev/null 2>&1; then
+    echo "Main branch '$MAIN_BRANCH' not found locally; skipping bench cleanup." >&2
+    return
+  fi
+
+  mapfile -t merged_branches < <(git for-each-ref --format='%(refname:short)' --merged "$MAIN_BRANCH")
+  if [[ ${#merged_branches[@]} -eq 0 ]]; then
+    echo "No branches are merged into $MAIN_BRANCH; nothing to prune."
+    return
+  fi
+
+  deleted_any=0
+  for branch in "${merged_branches[@]}"; do
+    if [[ "$branch" == "$MAIN_BRANCH" ]]; then
+      continue
+    fi
+    if [[ "$branch" == bench* || "$branch" == *bench* || "$branch" == *Bench* ]]; then
+      if git branch -d "$branch" >/dev/null 2>&1; then
+        echo "Deleted merged bench branch '$branch'."
+        deleted_any=1
+      fi
+    fi
+  done
+
+  if [[ "$deleted_any" -eq 0 ]]; then
+    echo "No merged bench branches found to delete."
+  fi
+}
+
+check_remote
+cleanup_benches

--- a/server/integrations/openAiClient.js
+++ b/server/integrations/openAiClient.js
@@ -90,6 +90,104 @@ const parseContent = (choice) => {
   return "";
 };
 
+const coerceMessageText = (value) => {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((part) => {
+        if (typeof part === "string") {
+          return part;
+        }
+        if (typeof part?.text === "string") {
+          return part.text;
+        }
+        return "";
+      })
+      .join("");
+  }
+  if (value && typeof value === "object" && typeof value.text === "string") {
+    return value.text;
+  }
+  return "";
+};
+
+const getErrorStatusCode = (error) => {
+  if (!error) return undefined;
+  const possible = [
+    error.status,
+    error.statusCode,
+    error.code,
+    error?.response?.status,
+    error?.response?.statusCode,
+    error?.cause?.status,
+    error?.cause?.statusCode
+  ];
+  return possible.map(Number).find((value) => Number.isInteger(value)) ?? undefined;
+};
+
+const truncateText = (text, length = 200) => {
+  if (!text) return "";
+  if (text.length <= length) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, length - 1))}…`;
+};
+
+const fallbackComplianceStub = async ({ messages = [] }, { status } = {}) => {
+  const lastUserMessage = [...messages]
+    .reverse()
+    .find((message) => message?.role === "user");
+  const rawContent = coerceMessageText(lastUserMessage?.content);
+  const trimmed = rawContent.trim().replace(/\s+/g, " ");
+  const summary = truncateText(trimmed);
+
+  const noteSuffix = status ? ` (status ${status})` : "";
+  const complianceNotes = [
+    `Fallback compliance stub used after an OpenAI authorization failure${noteSuffix}.`
+  ];
+
+  const educationalRequests = summary
+    ? [`Free-form question logged for adviser review: ${summary}`]
+    : [];
+
+  const compliance = {
+    educational_requests: educationalRequests,
+    notes: complianceNotes
+  };
+
+  const reply = summary
+    ? `I couldn't reach the compliance assistant due to an authorization error, but I've logged your question about "${summary}" for an adviser review.`
+    : "I couldn't reach the compliance assistant due to an authorization error, but I've logged this question for an adviser review.";
+
+  return { reply, compliance };
+};
+
+const parseStrictFlag = (value) => {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
+};
+
+const truthyStrictValues = new Set(["1", "true", "yes", "on"]);
+
+const shouldFallbackToStubOnUnauthorizedInternal = (
+  error,
+  env = process.env
+) => {
+  const status = getErrorStatusCode(error);
+  if (status !== 401) {
+    return false;
+  }
+
+  const strict = parseStrictFlag(env.OPENAI_STRICT);
+  const strictEnabled = truthyStrictValues.has(strict);
+  return !strictEnabled;
+};
+
+export { shouldFallbackToStubOnUnauthorizedInternal as shouldFallbackToStubOnUnauthorized };
+
 const defaultResponder = async ({ messages, model = DEFAULT_MODEL }) => {
   const client = await getClient();
   const completion = await client.chat.completions.create({
@@ -117,6 +215,15 @@ export const setComplianceResponder = (fn) => {
 
 export const callComplianceResponder = async (payload) => {
   const handler = responder ?? defaultResponder;
-  return handler(payload);
+
+  try {
+    return await handler(payload);
+  } catch (error) {
+    if (shouldFallbackToStubOnUnauthorizedInternal(error)) {
+      const status = getErrorStatusCode(error);
+      return fallbackComplianceStub(payload, { status });
+    }
+    throw error;
+  }
 };
 

--- a/server/state/investmentUniverse.js
+++ b/server/state/investmentUniverse.js
@@ -1,0 +1,85 @@
+export const AUTHORIZED_INVESTMENTS = [
+  {
+    id: "aurora_green_growth",
+    name: "Aurora Green Growth Fund",
+    type: "Global Equity Fund",
+    provider: "Aurora Asset Management",
+    objectives: ["growth", "impact"],
+    labels: ["Sustainability: Impact"],
+    themes: ["Climate", "Energy transition"],
+    exclusions_supported: ["Thermal coal under 5%", "Tobacco 0%"],
+    risk_band: [4, 6],
+    min_horizon_years: 5,
+    preference_levels: ["high_level", "detailed"],
+    summary:
+      "Global equities focusing on companies delivering measurable climate transition outcomes with active stewardship.",
+    charges: "0.78% ongoing charge"
+  },
+  {
+    id: "sterling_sustainable_income",
+    name: "Sterling Sustainable Income Bond",
+    type: "Global Bond Fund",
+    provider: "Sterling Fixed Income Partners",
+    objectives: ["income", "preservation"],
+    labels: ["Sustainability: Improvers"],
+    themes: ["Social", "Climate"],
+    exclusions_supported: ["Thermal coal under 10%", "Controversial weapons 0%"],
+    risk_band: [2, 4],
+    min_horizon_years: 3,
+    preference_levels: ["high_level", "detailed"],
+    summary:
+      "Diversified investment grade bond portfolio engaging issuers on climate transition and workforce standards.",
+    charges: "0.52% ongoing charge"
+  },
+  {
+    id: "harbor_balanced_focus",
+    name: "Harbor ESG Balanced Focus Portfolio",
+    type: "Multi-Asset Model Portfolio",
+    provider: "Harbor Advisory Services",
+    objectives: ["growth", "preservation"],
+    labels: ["Sustainability: Focus"],
+    themes: ["Climate", "Biodiversity", "Corporate governance"],
+    exclusions_supported: ["Thermal coal under 5%", "Tobacco 0%", "Predatory lending 0%"],
+    risk_band: [3, 5],
+    min_horizon_years: 4,
+    preference_levels: ["high_level", "detailed"],
+    summary:
+      "Blended equity and bond model emphasising companies already leading on sustainability metrics.",
+    charges: "0.68% ongoing charge"
+  }
+];
+
+export const MARKET_ALTERNATIVES = [
+  {
+    id: "solstice_global_impact",
+    name: "Solstice Global Impact Opportunities",
+    type: "Global Equity Fund",
+    provider: "Solstice Capital",
+    objectives: ["growth", "impact"],
+    labels: ["Sustainability: Impact"],
+    themes: ["Climate", "Health"],
+    exclusions_supported: ["Thermal coal under 0%", "Tobacco 0%"],
+    risk_band: [4, 6],
+    min_horizon_years: 5,
+    preference_levels: ["detailed"],
+    summary:
+      "Concentrated portfolio targeting companies with verified impact metrics and outcome-linked remuneration.",
+    charges: "0.85% ongoing charge"
+  },
+  {
+    id: "northstar_responsible_credit",
+    name: "Northstar Responsible Credit Fund",
+    type: "Corporate Bond Fund",
+    provider: "Northstar Asset Co.",
+    objectives: ["income", "preservation"],
+    labels: ["Sustainability: Improvers"],
+    themes: ["Social", "Climate"],
+    exclusions_supported: ["Thermal coal under 20%", "Civilian firearms 0%"],
+    risk_band: [2, 4],
+    min_horizon_years: 3,
+    preference_levels: ["high_level", "detailed"],
+    summary:
+      "Investment grade credit fund with structured engagement milestones for issuers on net-zero and labour standards.",
+    charges: "0.60% ongoing charge"
+  }
+];

--- a/server/state/sessionStore.js
+++ b/server/state/sessionStore.js
@@ -97,6 +97,7 @@ const createEmptySessionData = (sessionId) => ({
   },
   educational_requests: [],
   extra_questions: [],
+  investment_research: [],
   additional_notes: ""
 });
 


### PR DESCRIPTION
## Summary
- move the unauthorized fallback helper behind an internal binding and export alias to avoid duplicate identifier declarations in ESM
- update the OpenAI client caller to reference the new internal helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68de46b508dc8329b0d99e2700c8974c