### PR TITLE
Gracefully handle missing ws dependency

### DIFF
--- a/server/monitoring/logger.js
+++ b/server/monitoring/logger.js
@@ -164,15 +164,29 @@ class Logger {
   // Specialized logging methods
   
   logRequest(req, res, responseTime) {
-    this.info('HTTP Request', {
-      method: req.method,
-      url: req.url,
-      userAgent: req.get('User-Agent'),
-      ip: req.ip || req.connection.remoteAddress,
-      statusCode: res.statusCode,
-      responseTime: `${responseTime}ms`,
-      contentLength: res.get('Content-Length')
-    });
+    try {
+      const context = {
+        method: req.method ?? 'UNKNOWN',
+        url: req.url ?? '',
+        userAgent: req.headers?.['user-agent'],
+        ip: req.socket?.remoteAddress ?? req.connection?.remoteAddress,
+        statusCode: typeof res.statusCode === 'number' ? res.statusCode : undefined,
+        responseTime: typeof responseTime === 'number' ? `${responseTime}ms` : undefined,
+        contentLength: typeof res.getHeader === 'function'
+          ? res.getHeader('content-length') ?? res.getHeader('Content-Length')
+          : undefined
+      };
+
+      for (const key of Object.keys(context)) {
+        if (context[key] === undefined || context[key] === null) {
+          delete context[key];
+        }
+      }
+
+      this.info('HTTP Request', context);
+    } catch (error) {
+      this.warn('Failed to log request', { error: error.message });
+    }
   }
   
   logSession(action, sessionId, context = {}) {

--- a/server/router.js
+++ b/server/router.js
@@ -215,16 +215,16 @@ const handleMultiModalInput = async (req, res, sessionId) => {
   }
 };
 
-const handleGetSessionAnalytics = (res, sessionId) => {
+const handleGetSessionAnalytics = async (res, sessionId) => {
   const session = ensureSession(res, sessionId);
   if (!session) return;
 
   try {
-    const { generateConversationSummary, analyzeConversationEffectiveness } = require("./state/conversationAnalytics.js");
-    
+    const { generateConversationSummary, analyzeConversationEffectiveness } = await import("./state/conversationAnalytics.js");
+
     const summary = generateConversationSummary(session);
     const effectiveness = analyzeConversationEffectiveness(session);
-    
+
     const analytics = {
       sessionId,
       summary,
@@ -1714,12 +1714,23 @@ const handleReviewRegulatoryChange = async (req, res, changeId) => {
 };
 
 export const handleRequest = async (req, res) => {
+  const startTime = Date.now();
+
   // Apply performance monitoring middleware
   performanceMiddleware(req, res, () => {});
-  
-  // Log request
-  logger.logRequest(req, res, 0); // Will be updated with actual response time
-  
+
+  let logged = false;
+  const logRequest = () => {
+    if (logged) return;
+    logged = true;
+    const responseTime = Date.now() - startTime;
+    logger.logRequest(req, res, responseTime);
+  };
+
+  res.on("finish", logRequest);
+  res.on("close", logRequest);
+  res.on("error", logRequest);
+
   if (req.method === "OPTIONS") {
     sendOptions(res);
     return;
@@ -1772,7 +1783,7 @@ export const handleRequest = async (req, res) => {
       }
 
       if (req.method === "GET" && tail === "analytics") {
-        handleGetSessionAnalytics(res, sessionId);
+        await handleGetSessionAnalytics(res, sessionId);
         return;
       }
 

--- a/server/server.js
+++ b/server/server.js
@@ -36,11 +36,15 @@ const server = http.createServer(async (req, res) => {
   }
 });
 
-server.listen(port, () => {
+server.listen(port, async () => {
   console.log(`Server ready on http://localhost:${port}`);
-  
+
   // Initialize WebSocket session monitor
-  sessionMonitor.initialize(server);
+  try {
+    await sessionMonitor.initialize(server);
+  } catch (error) {
+    console.error('Failed to initialize WebSocket session monitor', error);
+  }
 });
 
 process.on("SIGINT", () => {

--- a/server/state/conversationEngine.js
+++ b/server/state/conversationEngine.js
@@ -74,12 +74,17 @@ import {
 
 // Import session monitor for real-time notifications
 let sessionMonitor = null;
-try {
-  const { sessionMonitor: monitor } = await import("../websocket/sessionMonitor.js");
-  sessionMonitor = monitor;
-} catch (error) {
-  // WebSocket monitor not available, continue without real-time features
-}
+import("../websocket/sessionMonitor.js")
+  .then(({ sessionMonitor: monitor }) => {
+    sessionMonitor = monitor;
+  })
+  .catch((error) => {
+    if (error?.code === 'ERR_MODULE_NOT_FOUND' || error?.code === 'MODULE_NOT_FOUND') {
+      console.log('WebSocket session monitor not available');
+    } else {
+      console.error('Failed to load WebSocket session monitor', error);
+    }
+  });
 import { validateSessionData } from "./validateSession.js";
 import {
   AUTHORIZED_INVESTMENTS,

--- a/server/state/sessionStore.js
+++ b/server/state/sessionStore.js
@@ -17,13 +17,18 @@ import logger from "../monitoring/logger.js";
 
 // Import session monitor for real-time notifications
 let sessionMonitor = null;
-try {
-  const { sessionMonitor: monitor } = await import("../websocket/sessionMonitor.js");
-  sessionMonitor = monitor;
-} catch (error) {
-  // WebSocket monitor not available, continue without real-time features
-  console.log('WebSocket session monitor not available');
-}
+import("../websocket/sessionMonitor.js")
+  .then(({ sessionMonitor: monitor }) => {
+    sessionMonitor = monitor;
+  })
+  .catch((error) => {
+    // WebSocket monitor not available, continue without real-time features
+    if (error?.code === 'ERR_MODULE_NOT_FOUND' || error?.code === 'MODULE_NOT_FOUND') {
+      console.log('WebSocket session monitor not available');
+    } else {
+      console.error('Failed to load WebSocket session monitor', error);
+    }
+  });
 
 const createEmptySessionData = (sessionId) => ({
   session_id: sessionId,

--- a/server/websocket/sessionMonitor.js
+++ b/server/websocket/sessionMonitor.js
@@ -1,7 +1,32 @@
-import { WebSocketServer } from 'ws';
 import { randomUUID } from 'node:crypto';
 import { getSession, getSessionEnhanced } from '../state/sessionStore.js';
 import { validateSessionData } from '../state/validateSession.js';
+
+let WebSocketServer = null;
+let websocketModulePromise = null;
+
+const loadWebSocketServer = () => {
+  if (!websocketModulePromise) {
+    websocketModulePromise = import('ws')
+      .then((module) => {
+        const exported = module?.WebSocketServer ?? module?.default ?? null;
+        if (!exported) {
+          console.warn('WebSocket session monitor disabled: ws package has no WebSocketServer export');
+        }
+        return exported;
+      })
+      .catch((error) => {
+        if (error?.code === 'ERR_MODULE_NOT_FOUND' || error?.code === 'MODULE_NOT_FOUND') {
+          console.log('WebSocket session monitor not available');
+        } else {
+          console.error('Failed to load ws package for session monitor', error);
+        }
+        return null;
+      });
+  }
+
+  return websocketModulePromise;
+};
 
 class SessionMonitor {
   constructor() {
@@ -14,8 +39,20 @@ class SessionMonitor {
     this.setupDefaultAlertRules();
   }
 
-  initialize(server) {
-    this.wss = new WebSocketServer({ 
+  async initialize(server) {
+    if (this.wss) {
+      return;
+    }
+
+    if (!WebSocketServer) {
+      WebSocketServer = await loadWebSocketServer();
+    }
+
+    if (!WebSocketServer) {
+      return;
+    }
+
+    this.wss = new WebSocketServer({
       server,
       path: '/ws/sessions'
     });


### PR DESCRIPTION
## Summary
- lazily load the `ws` module inside the session monitor so imports succeed even when the dependency is unavailable
- switch session state modules to non-blocking session monitor imports to avoid circular waits during startup
- await session monitor initialization at server boot and surface initialization errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_6900e397e50c8329bad7672895774c87